### PR TITLE
Add toggleReaction mutation.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -4,6 +4,7 @@ import {
   transformItem,
   transformCollection,
   authorizedRequest,
+  requireAuthorizedRequest,
 } from './helpers';
 
 const ROGUE_URL = config('services.rogue.url');
@@ -95,6 +96,21 @@ export const getPostsBySignupId = async (id, context) => {
   const json = await response.json();
 
   return transformCollection(json);
+};
+
+/**
+ * Toggle a reaction on Rogue.
+ *
+ * @param {Number} postId
+ * @return {Object}
+ */
+export const toggleReaction = async (postId, context) => {
+  await fetch(`${ROGUE_URL}/api/v3/post/${postId}/reactions`, {
+    ...requireAuthorizedRequest(context),
+    method: 'POST',
+  });
+
+  return getPostById(postId, context);
 };
 
 /**

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -10,6 +10,7 @@ import Rogue, {
   getPostsBySignupId,
   getPostById,
   getSignups,
+  toggleReaction,
 } from '../repositories/rogue';
 
 /**
@@ -153,6 +154,10 @@ const typeDefs = gql`
       count: Int = 20
     ): [Signup]
   }
+
+  type Mutation {
+    toggleReaction(postId: Int!): Post
+  }
 `;
 
 /**
@@ -186,6 +191,9 @@ const resolvers = {
       getPostsByUserId(args.id, args.page, args.count, context),
     signup: (_, args, context) => Rogue(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args.page, args.count, context),
+  },
+  Mutation: {
+    toggleReaction: (_, args, context) => toggleReaction(args.postId, context),
   },
 };
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -156,7 +156,11 @@ const typeDefs = gql`
   }
 
   type Mutation {
-    toggleReaction(postId: Int!): Post
+    # Add or remove a reaction to a post. Requires an access token.
+    toggleReaction(
+      # The post ID to react to.
+      postId: Int!
+    ): Post
   }
 `;
 


### PR DESCRIPTION
#### What's this PR do?
This pull request adds our first mutation to the GraphQL schema - `toggleReaction`! Woo! ❤️

#### How should this be reviewed?
Here's some background on [mutations](http://graphql.org/learn/queries/#mutations). I added the mutation to the schema and resolvers in `src/schema/rogue.js`, which talks to the repository to make the appropriate REST API calls in `src/repositories/rogue.js`. For convenience, we return a `Post` here instead of a `Reaction`.

#### Any background context you want to provide?
This will allow us to update reactions via GraphQL in Phoenix Next's new galleries!

#### Relevant tickets
[#155944555](https://www.pivotaltracker.com/story/show/155944555)