### PR TITLE
Make new loader per GraphQL request.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,0 +1,29 @@
+import { set } from 'lodash';
+import logger from 'heroku-logger';
+import DataLoader from 'dataloader';
+
+import { getSignupsById } from './repositories/rogue';
+import { getUserById } from './repositories/northstar';
+import { authorizedRequest } from './repositories/helpers';
+
+/**
+ * The data loader handles batching and caching the backend
+ * requests needed for a single GraphQL query.
+ *
+ * @var {DataLoader}
+ */
+export default context => {
+  // If this is a new GraphQL request, configure a loader.
+  if (!context.loader) {
+    logger.debug('Creating a new loader for this GraphQL request.');
+    const options = authorizedRequest(context);
+    set(context, 'loader', {
+      users: new DataLoader(ids =>
+        Promise.all(ids.map(id => getUserById(id, options))),
+      ),
+      signups: new DataLoader(ids => getSignupsById(ids, options)),
+    });
+  }
+
+  return context.loader;
+};

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -1,9 +1,7 @@
-import { set } from 'lodash';
 import logger from 'heroku-logger';
-import DataLoader from 'dataloader';
 
 import config from '../../config';
-import { authorizedRequest, transformItem } from './helpers';
+import { transformItem } from './helpers';
 
 const NORTHSTAR_URL = config('services.northstar.url');
 
@@ -12,7 +10,7 @@ const NORTHSTAR_URL = config('services.northstar.url');
  *
  * @return {Object}
  */
-const getUserById = async (id, options) => {
+export const getUserById = async (id, options) => {
   logger.debug('Loading user from Northstar', { id });
   try {
     const response = await fetch(`${NORTHSTAR_URL}/v1/users/id/${id}`, options);
@@ -27,24 +25,4 @@ const getUserById = async (id, options) => {
   return null;
 };
 
-/**
- * Northstar data loader.
- *
- * @var {Northstar}
- */
-const Northstar = context => {
-  // If this is a new GraphQL request, configure a loader.
-  if (!context.northstar) {
-    logger.debug('Creating a new loader for Northstar.');
-    const options = authorizedRequest(context);
-    set(context, 'northstar', {
-      users: new DataLoader(ids =>
-        Promise.all(ids.map(id => getUserById(id, options))),
-      ),
-    });
-  }
-
-  return context.northstar;
-};
-
-export default Northstar;
+export default null;

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -1,4 +1,4 @@
-import DataLoader from 'dataloader';
+import logger from 'heroku-logger';
 import { stringify } from 'qs';
 
 import config from '../../config';
@@ -170,7 +170,9 @@ export const getSignupById = async (id, context) => {
  * @param {Number} count
  * @return {Array}
  */
-const getSignupsById = async (ids, options) => {
+export const getSignupsById = async (ids, options) => {
+  logger.debug('Loading signups from Rogue', { ids });
+
   const idQuery = ids.join(',');
   const response = await fetch(
     `${ROGUE_URL}/api/v3/signups/?filter[id]=${
@@ -182,24 +184,3 @@ const getSignupsById = async (ids, options) => {
 
   return transformCollection(json);
 };
-
-/**
- * Rogue data loader.
- *
- * @var {Northstar}
- */
-let instance = null;
-const Rogue = context => {
-  if (instance) return instance;
-
-  // Configure a new loader for the request.
-  const options = authorizedRequest(context);
-
-  instance = {
-    signups: new DataLoader(ids => getSignupsById(ids, options)),
-  };
-
-  return instance;
-};
-
-export default Rogue;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -2,7 +2,8 @@ import { makeExecutableSchema } from 'graphql-tools';
 import gql from 'tagged-template-noop';
 import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
-import northstar from '../repositories/northstar';
+
+import Loader from '../loader';
 
 /**
  * GraphQL types.
@@ -120,7 +121,7 @@ const resolvers = {
     role: user => user.role.toUpperCase(),
   },
   Query: {
-    user: (_, args, context) => northstar(context).users.load(args.id),
+    user: (_, args, context) => Loader(context).users.load(args.id),
   },
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -3,7 +3,8 @@ import { GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 import gql from 'tagged-template-noop';
 import { urlWithQuery } from '../repositories/helpers';
-import Rogue, {
+import Loader from '../loader';
+import {
   getPosts,
   getPostsByUserId,
   getPostsByCampaignId,
@@ -188,7 +189,8 @@ const resolvers = {
     url: (media, args) => urlWithQuery(media.url, args),
   },
   Post: {
-    signup: (post, args, context) => Rogue(context).signups.load(post.signupId),
+    signup: (post, args, context) =>
+      Loader(context).signups.load(post.signupId),
     url: (post, args) => urlWithQuery(post.media.url, args),
     text: post => post.media.text,
     status: post => post.status.toUpperCase(),
@@ -205,7 +207,7 @@ const resolvers = {
       getPostsByCampaignId(args.id, args.page, args.count, context),
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
-    signup: (_, args, context) => Rogue(context).signups.load(args.id),
+    signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args.page, args.count, context),
   },
   Mutation: {


### PR DESCRIPTION
I had a sudden epiphany this Sunday, and it has manifested in this pull request. Since Node keeps a long lived server (rather than spinning up a new "app" for each request, like our good friend PHP), we were sharing the same [DataLoader](https://github.com/facebook/dataloader) instance for everything (not _just_ for requests on the same query). Ayyyy!

This pull request stores the loader on the context (which is specific to each query), so that we can batch-load and cache entities that get repeated within a single request but we don't get carried away and keep filling up that same cache forever and ever.