### PR TITLE
Configure server for persisted queries.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -54,7 +54,19 @@ app.use(cors());
 
   // Start Apollo Engine server if we have an API key.
   if (apolloEngineApiKey) {
-    const engine = new ApolloEngine({ apiKey: apolloEngineApiKey });
+    const engine = new ApolloEngine({
+      apiKey: apolloEngineApiKey,
+      // Set CORS headers for Automatic Persisted Query support in Apollo Engine.
+      // <https://www.apollographql.com/docs/engine/auto-persisted-queries.html#setup>
+      frontends: [
+        {
+          overrideGraphqlResponseHeaders: {
+            'Access-Control-Allow-Origin': '*',
+          },
+        },
+      ],
+    });
+
     const engineConfig = {
       graphqlPaths: ['/graphql'],
       expressApp: app,


### PR DESCRIPTION
Since we serve GraphQL queries off of `graphql.dosomething.org` (etc.), we need to tell Apollo Engine to add a CORS header to any responses it serves for us, for example for [persisted queries](https://www.apollographql.com/docs/engine/auto-persisted-queries.html).