### PR TITLE
Hard-coded type filter to eliminate Social Share posts

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -85,9 +85,9 @@ export const getPostsByUserId = async (id, page, count, context) => {
  */
 export const getPostsByCampaignId = async (id, page, count, context) => {
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?filter[campaign_id]=${id}&page=${page}&limit=${
-      count
-    }&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/posts/?filter[campaign_id]=${
+      id
+    }&filter[type]=photo,text&page=${page}&limit=${count}&pagination=cursor`,
     authorizedRequest(context),
   );
 


### PR DESCRIPTION
### What does this PR do?
It adds a hardcoded `type` filter to the `getPostsByCampaignId` query to ensure that only get `photo` and `text` posts are returned.

### Uhh some background, maybe?
We recently started storing `share-social` Reportbacks (posts) in Rogue, and were seeing these posts show up on Campaigns in a rather ugly format (not much to display about a social-share post visually atm):
![image](https://user-images.githubusercontent.com/12417657/45049552-fa692d00-b04c-11e8-8a56-ddcc23d8d1cc.png)
😰 🙄 🤕 👎 

But with the filter:
![image](https://user-images.githubusercontent.com/12417657/45051095-0c4ccf00-b051-11e8-8b2b-0ddf0caa3111.png)

🎊 😆 👍 🍾 


This is a temporary hardcoded quick-fix solution. With existing plans to add formal type filtering soon!


[Pivotal ID #160172984](https://www.pivotaltracker.com/story/show/160172984)

