### PR TITLE
Filter getPostsByUserId query by type

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -66,9 +66,9 @@ export const getPostById = async (id, context) => {
  */
 export const getPostsByUserId = async (id, page, count, context) => {
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?filter[northstar_id]=${id}&page=${page}&limit=${
-      count
-    }&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/posts/?filter[northstar_id]=${
+      id
+    }&filter[type]=photo,text&page=${page}&limit=${count}&pagination=cursor`,
     authorizedRequest(context),
   );
 


### PR DESCRIPTION
### What's this all about?
We're adding a quick filter for the `getPostsByUserId` query by `type` and limiting to `text` or `photo`. 

### Talk more
This is temporary. We're doing this for the same reason as #19. We're using this query in user Profile pages in Phoenix Next.

### Hand me some refs
[Pivotal ID #160603808](https://www.pivotaltracker.com/story/show/160603808)