### PR TITLE
Topic + Broadcast interface

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -5,7 +5,7 @@ import DataLoader from 'dataloader';
 import { getCampaignById, getSignupsById } from './repositories/rogue';
 import { getUserById } from './repositories/northstar';
 import { getConversationById } from './repositories/gambitConversations';
-import { getBroadcastById, getTopicById } from './repositories/gambitContent';
+import { getGambitContentfulEntryById } from './repositories/gambitContent';
 import { authorizedRequest } from './repositories/helpers';
 
 /**
@@ -21,7 +21,7 @@ export default context => {
     const options = authorizedRequest(context);
     set(context, 'loader', {
       broadcasts: new DataLoader(ids =>
-        Promise.all(ids.map(id => getBroadcastById(id, options))),
+        Promise.all(ids.map(id => getGambitContentfulEntryById(id, options))),
       ),
       campaigns: new DataLoader(ids =>
         Promise.all(ids.map(id => getCampaignById(id, options))),
@@ -34,7 +34,7 @@ export default context => {
       ),
       signups: new DataLoader(ids => getSignupsById(ids, options)),
       topics: new DataLoader(ids =>
-        Promise.all(ids.map(id => getTopicById(id, options))),
+        Promise.all(ids.map(id => getGambitContentfulEntryById(id, options))),
       ),
     });
   }

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -59,8 +59,8 @@ const getFields = json => {
 
   if (type === 'autoReply') {
     return {
-      campaignId: getCampaignId(json),
       autoReply: fields.autoReply,
+      campaignId: getCampaignId(json),
     };
   }
 
@@ -80,11 +80,18 @@ const getFields = json => {
 
   if (type === 'photoPostConfig') {
     return {
-      campaignId: getCampaignId(json),
+      askCaption: fields.askCaptionMessage,
       askPhoto: fields.askPhotoMessage,
       askQuantity: fields.askQuantityMessage,
+      askWhyParticipated: fields.askWhyParticipatedMessage,
+      campaignId: getCampaignId(json),
+      completedPhotoPost: fields.completedMenuMessage,
+      completedPhotoPostAutoReply: fields.invalidCompletedMenuCommandMessage,
+      invalidCaption: fields.invalidCaptionMessage,
       invalidQuantity: fields.invalidQuantityMessage,
       invalidPhoto: fields.invalidPhotoMessage,
+      invalidWhyParticipated: fields.invalidWhyParticipatedMessage,
+      startPhotoPostAutoReply: fields.invalidSignupMenuCommandMessage,
     };
   }
 
@@ -98,8 +105,8 @@ const getFields = json => {
   if (type === 'textPostConfig') {
     return {
       campaignId: getCampaignId(json),
-      invalidText: fields.invalidTextMessage,
       completedTextPost: fields.completedTextPostMessage,
+      invalidText: fields.invalidTextMessage,
     };
   }
 
@@ -127,7 +134,11 @@ export const getGambitContentfulEntryById = async (id, context) => {
     return transformItem(json);
   } catch (exception) {
     const error = exception.message;
-    logger.warn('Unable to load entry.', { id, error, context });
+    logger.warn('Unable to load Gambit Contentful entry.', {
+      id,
+      error,
+      context,
+    });
   }
 
   return null;
@@ -139,7 +150,7 @@ export const getGambitContentfulEntryById = async (id, context) => {
  * @return {Array}
  */
 export const getBroadcasts = async (args, context) => {
-  logger.debug('Loading broadcasts from Gambit Content');
+  logger.debug('Loading broadcasts from Gambit Contentful');
 
   const broadcastTypes = [
     'autoReplyBroadcast',

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -26,7 +26,7 @@ const getCampaignId = json => {
  */
 const getChangeTopicId = json => {
   if (json.fields.topic) {
-    return json.sys.id;
+    return json.fields.topic.sys.id;
   }
   return null;
 };

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -11,26 +11,75 @@ const client = createClient({
 
 /**
  * @param {Object} entry
+ * @return {Number}
+ */
+const getCampaignId = entry => {
+  if (entry.fields.campaign) {
+    return entry.fields.campaign.fields.campaignId;
+  }
+  return null;
+};
+
+/**
+ * @param {Object} entry
+ * @return {String}
+ */
+const getContentType = entry => entry.sys.contentType.sys.id;
+
+/**
+ * @param {Object} entry
  * @return {Object}
  */
 const transformItem = entry => ({
   id: entry.sys.id,
-  type: entry.sys.contentType.sys.id,
+  type: getContentType(entry),
   createdAt: entry.sys.createdAt,
   updatedAt: entry.sys.updatedAt,
   name: entry.fields.name,
 });
 
 /**
+ * @param {Object} entry
+ * @return {Object}
+ */
+const getTopicFields = entry => {
+  const type = getContentType(entry);
+  const fields = entry.fields;
+
+  if (type === 'autoReply') {
+    return {
+      campaignId: getCampaignId(entry),
+      autoReply: entry.fields.autoReply,
+    };
+  }
+
+  if (type === 'photoPostConfig') {
+    return {
+      campaignId: getCampaignId(entry),
+      askPhoto: fields.askPhotoMessage,
+      askQuantity: fields.askQuantityMessage,
+      invalidQuantity: fields.invalidQuantityMessage,
+      invalidPhoto: fields.invalidPhotoMessage,
+    };
+  }
+
+  if (type === 'textPostConfig') {
+    return {
+      campaignId: getCampaignId(entry),
+      invalidText: fields.invalidTextMessage,
+      completedTextPost: fields.completedTextPostMessage,
+    };
+  }
+
+  return null;
+};
+
+/**
  * @param {Object} json
  * @return {Object}
  */
 const transformTopic = json =>
-  assign(transformItem(json), {
-    campaignId: json.fields.campaign
-      ? json.fields.campaign.fields.campaignId
-      : null,
-  });
+  assign(transformItem(json), getTopicFields(json));
 
 /**
  * @param {Object} json

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -83,20 +83,22 @@ const typeDefs = gql`
   type AutoReplyBroadcast implements Broadcast {
     ${broadcastFields}
     # The Auto Reply Topic ID to save as current topic.
-    topicId: Int!
+    topicId: String!
   }
 
   type PhotoPostBroadcast implements Broadcast {
     ${broadcastFields}
     # The Photo Post Topic ID to save as current topic.
-    topicId: Int!
+    topicId: String!
   }
 
   type TextPostBroadcast implements Broadcast {
     ${broadcastFields}
+    # The Photo Post Topic ID to save as current topic.
+    topicId: String!
   }
 
-  type GeneralBroadcast implements Broadcast {
+  type LegacyBroadcast implements Broadcast {
     ${broadcastFields}
   }
 
@@ -144,7 +146,7 @@ const resolvers = {
       if (broadcast.type === 'textPostBroadcast') {
         return 'TextPostBroadcast';
       }
-      return 'GeneralBroadcast';
+      return 'LegacyBroadcast';
     },
   },
   Query: {

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -82,20 +82,26 @@ const typeDefs = gql`
 
   type AutoReplyBroadcast implements Broadcast {
     ${broadcastFields}
-    # The Auto Reply Topic ID to save as current topic.
+    # The auto reply topic ID to change conversation to.
     topicId: String!
+    # The auto reply topic to change conversation to.
+    topic: AutoReplyTopic
   }
 
   type PhotoPostBroadcast implements Broadcast {
     ${broadcastFields}
-    # The Photo Post Topic ID to save as current topic.
+    # The photo post topic ID to change conversation to.
     topicId: String!
+    # The photo post topic to change conversation to.
+    topic: PhotoPostTopic
   }
 
   type TextPostBroadcast implements Broadcast {
     ${broadcastFields}
-    # The Photo Post Topic ID to save as current topic.
+    # The text post Topic ID to change conversation to.
     topicId: String!
+    # The text post topic to change conversation to.
+    topic: TextPostTopic
   }
 
   type LegacyBroadcast implements Broadcast {
@@ -135,6 +141,10 @@ const typeDefs = gql`
  * @var {Object}
  */
 const resolvers = {
+  AutoReplyBroadcast: {
+    topic: (broadcast, args, context) =>
+      Loader(context).topics.load(broadcast.topicId, context),
+  },
   Broadcast: {
     __resolveType(broadcast) {
       if (broadcast.type === 'autoReplyBroadcast') {
@@ -162,6 +172,14 @@ const resolvers = {
       Loader(context).broadcasts.load(args.id),
     textPostTopic: (_, args, context) => Loader(context).topics.load(args.id),
     topic: (_, args, context) => Loader(context).topics.load(args.id),
+  },
+  PhotoPostBroadcast: {
+    topic: (broadcast, args, context) =>
+      Loader(context).topics.load(broadcast.topicId, context),
+  },
+  TextPostBroadcast: {
+    topic: (broadcast, args, context) =>
+      Loader(context).topics.load(broadcast.topicId, context),
   },
   Topic: {
     __resolveType(topic) {

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -80,12 +80,6 @@ const typeDefs = gql`
     ${broadcastFields}
   }
 
-  type AskYesNo implements Broadcast, Topic {
-    ${broadcastFields}
-    # Template sent if user replies with a yes to the broadcast.
-    saidYes: String!
-  }
-
   type AutoReplyBroadcast implements Broadcast {
     ${broadcastFields}
     # The Auto Reply Topic ID to save as current topic.
@@ -107,6 +101,10 @@ const typeDefs = gql`
   }
 
   type Query {
+    # Get a Auto Reply Broadcast by ID.
+    autoReplyBroadcast(id: String!): AutoReplyBroadcast
+    # Get a Auto Reply Broadcast by ID.
+    autoReplyTopic(id: String!): AutoReplyBroadcast
     # Get a broadcast by ID.
     broadcast(id: String!): Broadcast
     # Get a paginated collection of broadcasts.
@@ -116,6 +114,14 @@ const typeDefs = gql`
       # The number of results per page.
       count: Int = 20
     ): [Broadcast]
+    # Get a Photo Post Broadcast by ID.
+    photoPostBroadcast(id: String!): PhotoPostBroadcast
+    # Get a Photo Post Topic by ID.
+    photoPostTopic(id: String!): PhotoPostTopic
+    # Get a Text Post Broadcast by ID.
+    textPostBroadcast(id: String!): TextPostBroadcast
+    # Get a Text Post Topic by ID.
+    textPostTopic(id: String!): TextPostTopic
     # Get a topic by ID.
     topic(id: String!): Topic
   }
@@ -142,8 +148,17 @@ const resolvers = {
     },
   },
   Query: {
+    autoReplyBroadcast: (_, args, context) =>
+      Loader(context).broadcasts.load(args.id),
+    autoReplyTopic: (_, args, context) => Loader(context).topics.load(args.id),
     broadcast: (_, args, context) => Loader(context).broadcasts.load(args.id),
     broadcasts: (_, args, context) => getBroadcasts(args, context),
+    photoPostBroadcast: (_, args, context) =>
+      Loader(context).broadcasts.load(args.id),
+    photoPostTopic: (_, args, context) => Loader(context).topics.load(args.id),
+    textPostBroadcast: (_, args, context) =>
+      Loader(context).broadcasts.load(args.id),
+    textPostTopic: (_, args, context) => Loader(context).topics.load(args.id),
     topic: (_, args, context) => Loader(context).topics.load(args.id),
   },
   Topic: {

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -5,6 +5,15 @@ import Loader from '../loader';
 
 import { getBroadcasts } from '../repositories/gambitContent';
 
+const entryFields = `
+  # The entry ID.
+  id: String
+  # The entry name.
+  name: String
+  # The entry type (e.g. 'photoPostConfig', 'askYesNo').
+  type: String
+`;
+
 /**
  * GraphQL types.
  *
@@ -12,25 +21,53 @@ import { getBroadcasts } from '../repositories/gambitContent';
  */
 const typeDefs = gql`
   # A DoSomething.org chatbot topic.
-  type Topic {
-    # The topic ID.
+  interface Topic {
+    ${entryFields}
+  }
+
+  type RivescriptTopic implements Topic {
+    # The Rivescript topic (e.g. 'unsubscribed', 'support')
     id: String
-    # The topic name.
     name: String
-    # The topic type (e.g. 'photoPostConfig', 'askYesNo').
+    # The topic type
     type: String
-    # The topic campaign ID (optional)
+  }
+
+  type AutoReplyTopic implements Topic {
+    ${entryFields}
+    # The campaign to create signup for if conversation changes to this topic (optional).
     campaignId: Int
+    # The auto reply text.
+    text: String
+  }
+
+  type PhotoPostTopic implements Topic {
+    ${entryFields}
+    # The campaign to create signup and photo post for if conversation changes to this topic.
+    campaignId: Int
+    # Template that asks user to reply with quantity.
+    askQuantity: String
+    # Template that asks user to resend a message with valid quantity.
+    invalidQuantity: String
+    # Template that asks user to reply with a photo.
+    askPhoto: String
+    # Template that asks user to resend a message with a valid photo.
+    invalidPhoto: String
+  }
+
+  type TextPostTopic implements Topic {
+    ${entryFields}
+    # The campaign to create signup and text post for if conversation changes to this topic.
+    campaignId: Int
+    # Template that asks user to resend a message with valid text post.
+    invalidText: String
+    # Template that confirms a text post was created.
+    completedTextPost: String
   }
 
   # A DoSomething.org chatbot broadcast.
   type Broadcast {
-    # The broadcast ID.
-    id: String
-    # The broadcast name.
-    name: String
-    # The broadcast type (e.g. 'photoPostBroadcast', 'askYesNo').
-    type: String
+    ${entryFields}
     # The broadcast text
     text: String
   }
@@ -60,6 +97,20 @@ const resolvers = {
     broadcast: (_, args, context) => Loader(context).broadcasts.load(args.id),
     broadcasts: (_, args, context) => getBroadcasts(args, context),
     topic: (_, args, context) => Loader(context).topics.load(args.id),
+  },
+  Topic: {
+    __resolveType(topic) {
+      if (topic.type === 'autoReply') {
+        return 'AutoReplyTopic';
+      }
+      if (topic.type === 'photoPostConfig') {
+        return 'PhotoPostTopic';
+      }
+      if (topic.type === 'textPostConfig') {
+        return 'TextPostTopic';
+      }
+      return 'RivescriptTopic';
+    },
   },
 };
 

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -40,7 +40,7 @@ const typeDefs = gql`
     type: String
   }
 
-  # An auto reply chatbot topic (creates signup if has a campaign).
+  # Topic for sending an auto-reply message (creates signup if it has a campaign set)
   type AutoReplyTopic implements Topic {
     ${entryFields}
     # The campaign to create signup for if conversation changes to this topic (optional).
@@ -49,29 +49,43 @@ const typeDefs = gql`
     autoReply: String!
   }
 
-  # A chatbot topic to create photo posts.
+  # Topic for creating signup and photo posts. Asks user to text START to begin a photo post.
   type PhotoPostTopic implements Topic {
     ${entryFields}
     # The campaign to create signup and photo post for if conversation changes to this topic.
     campaignId: Int!
+    # Template sent until user replies with START to begin a photo post.
+    startPhotoPostAutoReply: String!
     # Template that asks user to reply with quantity.
     askQuantity: String!
     # Template that asks user to resend a message with valid quantity.
     invalidQuantity: String!
     # Template that asks user to reply with a photo.
     askPhoto: String!
-    # Template that asks user to resend a message with a valid photo.
+    # Template that asks user to resend a message with a photo.
     invalidPhoto: String!
+    # Template that asks user to reply with a photo caption.
+    askCaption: String!
+    # Template that asks user to resend a message with a valid photo caption.
+    invalidCaption: String!
+    # Template that asks user to reply with why participated.
+    askWhyParticipated: String!
+    # Template that asks user to resend a message with a valid why participated.
+    invalidWhyParticipated: String!
+    # Template that confirms a photo post was created.
+    completedPhotoPost: String!
+    # Template sent after photo post confirmation. User can text START to submit another photo post.
+    completedPhotoPostAutoReply: String!
   }
 
-  # A chatbot topic to create text posts.
+  # Topic for creating signup and text posts. Ask user to text back a test post.
   type TextPostTopic implements Topic {
     ${entryFields}
     # The campaign to create signup and text post for if conversation changes to this topic.
     campaignId: Int!
     # Template that asks user to resend a message with valid text post.
     invalidText: String!
-    # Template that confirms a text post was created.
+    # Template that confirms a text post was created. Replying to this creates another text post.
     completedTextPost: String!
   }
 
@@ -80,6 +94,7 @@ const typeDefs = gql`
     ${broadcastFields}
   }
 
+  # Broadcast that changes topic to an auto reply.
   type AutoReplyBroadcast implements Broadcast {
     ${broadcastFields}
     # The auto reply topic ID to change conversation to.
@@ -88,6 +103,7 @@ const typeDefs = gql`
     topic: AutoReplyTopic
   }
 
+  # Broadcast that changes topic to a photo post, asks user to reply START to create/continue draft.
   type PhotoPostBroadcast implements Broadcast {
     ${broadcastFields}
     # The photo post topic ID to change conversation to.
@@ -96,6 +112,7 @@ const typeDefs = gql`
     topic: PhotoPostTopic
   }
 
+  # Broadcast that changes topic to a text post, asks user to reply with a text post.
   type TextPostBroadcast implements Broadcast {
     ${broadcastFields}
     # The text post Topic ID to change conversation to.

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -46,8 +46,18 @@ const linkSchema = gql`
     topic: Topic
   }
 
-  extend type Topic {
-    # The campaign that this topic should create activity for.
+  extend type AutoReplyTopic {
+    # The campaign that this topic should create signups and posts for.
+    campaign: Campaign
+  }
+
+  extend type PhotoPostTopic {
+    # The campaign that this topic should create signups and posts for.
+    campaign: Campaign
+  }
+
+  extend type TextPostTopic {
+    # The campaign that this topic should create signups and posts for.
     campaign: Campaign
   }
 `;
@@ -201,9 +211,43 @@ const linkResolvers = {
       },
     },
   },
-  Topic: {
+  AutoReplyTopic: {
     campaign: {
-      fragment: 'fragment CampaignFragment on Topic { campaignId }',
+      fragment: 'fragment CampaignFragment on AutoReplyTopic { campaignId }',
+      resolve(topic, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: rogueSchema,
+          operation: 'query',
+          fieldName: 'campaign',
+          args: {
+            id: topic.campaignId,
+          },
+          context,
+          info,
+        });
+      },
+    },
+  },
+  PhotoPostTopic: {
+    campaign: {
+      fragment: 'fragment CampaignFragment on PhotoPostTopic { campaignId }',
+      resolve(topic, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: rogueSchema,
+          operation: 'query',
+          fieldName: 'campaign',
+          args: {
+            id: topic.campaignId,
+          },
+          context,
+          info,
+        });
+      },
+    },
+  },
+  TextPostTopic: {
+    campaign: {
+      fragment: 'fragment CampaignFragment on TextPostTopic { campaignId }',
       resolve(topic, args, context, info) {
         return info.mergeInfo.delegateToSchema({
           schema: rogueSchema,


### PR DESCRIPTION
Wading further into the deep end, this PR branches off #33 to refactor the `Topic` and `Broadcast` types as interfaces, and adds topics/broadcasts for auto replies, photo posts, and text posts. The notion of deprecating Gambit Campaigns for this approach is feeling pretty decent! 🌤 

Example request:
```
{
  textPostTopic(id: "7dgk6mF2UM2U0y2E8ieAEi") {
    name
    type
    invalidText
    completedTextPost
    campaign {
      id
      internalTitle
      endDate
    }
  }
}
```

Example response: 
```
{
  "data": {
    "textPostTopic": {
      "campaign": {
        "endDate": "2019-02-21T00:00:00Z",
        "id": 9000,
        "internalTitle": "Not-So-Secret Admirer Beta Campaign 2019-01"
      },
      "completedTextPost": "Thanks for sharing! We love reading and celebrating everyone's passions! We’ll follow up next week with some tips to take your passions to the next level. In the meantime, here’s a quick tip: break down your big goals into smaller, bite-sized goals that you can achieve over time.",
      "invalidText": "Sorry, I didn't understand that. Text Q if you have a question.\n\nWhat's one thing you're especially passionate about? It could be anything - like making music or creating your own apps.",
      "name": "Not-So-Secret Admirer - Beta Text",
      "type": "textPostConfig"
    }
  }
```