### PR TITLE
Enable CORS for OPTIONS requests.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -37,8 +37,10 @@ if (app.get('env') === 'production') {
 // Use Helmet for security headers.
 app.use(helmet({ noCache: true }));
 
-// Allow cross-origin requests from client-side apps.
+// Allow cross-origin requests from client-side apps,
+// including 'OPTIONS' for pre-flight requests.
 app.use(cors());
+app.options('*', cors());
 
 // Register routes & start it up!
 (async () => {


### PR DESCRIPTION
This pull request enables CORS [for `OPTIONS` HTTP requests](https://github.com/expressjs/cors#enabling-cors-pre-flight). This should hopefully address [an issue](https://dosomething.slack.com/archives/C3ASB4204/p1547495946093100) we're seeing on dev, where GraphQL requests are failing with `Preflight response is not successful`.