### PR TITLE
Gambit Content caching

### DIFF
--- a/config/services.js
+++ b/config/services.js
@@ -56,6 +56,10 @@ const environments = {
     gambitContent: {
       spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,
       accessToken: process.env.GAMBIT_CONTENTFUL_ACCESS_TOKEN,
+      cache: {
+        name: 'gambitContent',
+        ttl: 3600,
+      },
     },
     gambitConversations: {
       url: 'https://gambit-conversations-staging.herokuapp.com',
@@ -90,6 +94,10 @@ const environments = {
     gambitContent: {
       spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,
       accessToken: process.env.GAMBIT_CONTENTFUL_ACCESS_TOKEN,
+      cache: {
+        name: 'gambitContent',
+        ttl: 3600,
+      },
     },
     gambitConversations: {
       url: 'https://gambit-conversations-prod.herokuapp.com',

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,6 +782,38 @@
         }
       }
     },
+    "cacheman": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cacheman/-/cacheman-2.2.1.tgz",
+      "integrity": "sha1-NRDA3vEkKdYbeAEo/xj50oS7Arg=",
+      "requires": {
+        "cacheman-memory": "1.1.0",
+        "ms": "0.7.3"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+        }
+      }
+    },
+    "cacheman-memory": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cacheman-memory/-/cacheman-memory-1.1.0.tgz",
+      "integrity": "sha512-jZ/Sg/LdgkN+T3G0BV3ekYzCAswKwZRBOvOmZ/VYwdhSTtMz6irMOt1JppBGZ7zVdjcBeku9tfOzb49KbXIT2w==",
+      "requires": {
+        "lru-cache": "4.1.4"
+      }
+    },
+    "cacheman-redis": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cacheman-redis/-/cacheman-redis-2.0.0.tgz",
+      "integrity": "sha512-QTcVLBprPh/E4VrrVpCpbuZ5cb29UrGHFrJgqS60059PkzhqqMc5uXakQADY0HChtMMK3GInZ+wM9ra1WECZAQ==",
+      "requires": {
+        "parse-redis-url": "0.0.2"
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -4255,6 +4287,11 @@
       "requires": {
         "error-ex": "1.3.2"
       }
+    },
+    "parse-redis-url": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/parse-redis-url/-/parse-redis-url-0.0.2.tgz",
+      "integrity": "sha1-E8kqCrvm8lEgBqjEnebLe43Usnc="
     },
     "parseurl": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "async-file": "^2.0.2",
     "body-parser": "^1.18.2",
     "boxen": "^1.3.0",
+    "cacheman": "^2.2.1",
+    "cacheman-redis": "^2.0.0",
     "chalk": "^2.4.1",
     "connect-redis": "^3.3.3",
     "contentful": "^7.0.6",
@@ -91,6 +93,7 @@
     "openid-client": "^2.4.5",
     "passport": "^0.4.0",
     "qs": "^6.5.1",
+    "redis": "^2.8.0",
     "serve-favicon": "^2.5.0",
     "tagged-template-noop": "^2.1.0"
   },

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -182,7 +182,7 @@ export const getGambitContentfulEntryById = async (id, context) => {
 
     const json = await contentfulClient.getEntry(id);
     const data = transformItem(json);
-    await cache.set(id, data);
+    cache.set(id, data);
 
     return data;
   } catch (exception) {

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -3,7 +3,7 @@ import redis from 'redis';
 import Cacheman from 'cacheman';
 import RedisEngine from 'cacheman-redis';
 import logger from 'heroku-logger';
-import { assign, map } from 'lodash';
+import { assign } from 'lodash';
 import config from '../../config';
 
 const contentfulClient = createClient({
@@ -192,38 +192,6 @@ export const getGambitContentfulEntryById = async (id, context) => {
       error,
       context,
     });
-  }
-
-  return null;
-};
-
-/**
- * Fetch broadcasts from Gambit Content.
- *
- * @return {Array}
- */
-export const getBroadcasts = async (args, context) => {
-  logger.debug('Loading broadcasts from Gambit Contentful');
-
-  const broadcastTypes = [
-    'autoReplyBroadcast',
-    'askSubscriptionStatus',
-    'askVotingPlanStatus',
-    'askYesNo',
-    'photoPostBroadcast',
-    'textPostBroadcast',
-  ];
-
-  try {
-    const query = { order: '-sys.createdAt' };
-    query['sys.contentType.sys.id[in]'] = broadcastTypes.join(',');
-
-    const json = await contentfulClient.getEntries(query);
-
-    return map(json.items, transformItem);
-  } catch (exception) {
-    const error = exception.message;
-    logger.warn('Unable to load broadcasts.', { error, context });
   }
 
   return null;

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -3,8 +3,6 @@ import gql from 'tagged-template-noop';
 
 import Loader from '../loader';
 
-import { getBroadcasts } from '../repositories/gambitContent';
-
 const entryFields = `
   # The entry ID.
   id: String
@@ -153,13 +151,6 @@ const typeDefs = gql`
     autoReplyTopic(id: String!): AutoReplyBroadcast
     # Get a broadcast by ID.
     broadcast(id: String!): Broadcast
-    # Get a paginated collection of broadcasts.
-    broadcasts(
-      # The page of results to return.
-      page: Int = 1
-      # The number of results per page.
-      count: Int = 20
-    ): [Broadcast]
     # Get a Photo Post Broadcast by ID.
     photoPostBroadcast(id: String!): PhotoPostBroadcast
     # Get a Photo Post Topic by ID.
@@ -213,7 +204,6 @@ const resolvers = {
       Loader(context).broadcasts.load(args.id),
     autoReplyTopic: (_, args, context) => Loader(context).topics.load(args.id),
     broadcast: (_, args, context) => Loader(context).broadcasts.load(args.id),
-    broadcasts: (_, args, context) => getBroadcasts(args, context),
     photoPostBroadcast: (_, args, context) =>
       Loader(context).broadcasts.load(args.id),
     photoPostTopic: (_, args, context) => Loader(context).topics.load(args.id),


### PR DESCRIPTION
Branching off of #35, this PR adds Redis caching to individual Contentful requests, and removes the `broadcasts` query to simplify things. Gambit Admin can query Gambit Content for paginated broadcasts for now (or Contentful, once we're getting closer to deprecating Gambit Content entirely) .