### PR TITLE
Adds Broadcast attachments field

### DIFF
--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -72,11 +72,15 @@ const getMessageText = json => json.fields.text;
  * @param {Object} json
  * @return {Array}
  */
-const getMessageAttachments = json =>
-  json.fields.attachments.map(attachment => ({
+const getMessageAttachments = json => {
+  if (!json.fields.attachments) {
+    return [];
+  }
+  return json.fields.attachments.map(attachment => ({
     url: attachment.fields.file.url,
     contentType: attachment.fields.file.contentType,
   }));
+};
 
 /**
  * @param {Object} json

--- a/src/repositories/gambitContent.js
+++ b/src/repositories/gambitContent.js
@@ -70,6 +70,16 @@ const getMessageText = json => json.fields.text;
 
 /**
  * @param {Object} json
+ * @return {Array}
+ */
+const getMessageAttachments = json =>
+  json.fields.attachments.map(attachment => ({
+    url: attachment.fields.file.url,
+    contentType: attachment.fields.file.contentType,
+  }));
+
+/**
+ * @param {Object} json
  * @return {Object}
  */
 const getSummary = json => ({
@@ -90,6 +100,7 @@ const getFields = json => {
 
   if (contentType === 'askYesNo') {
     return {
+      attachments: getMessageAttachments(json),
       invalidAskYesNoResponse: fields.invalidAskYesNoResponse,
       saidNo: getMessageText(fields.noTransition),
       saidNoTopicId: getChangeTopicId(fields.noTransition),
@@ -108,6 +119,7 @@ const getFields = json => {
 
   if (contentType === 'autoReplyBroadcast') {
     return {
+      attachments: getMessageAttachments(json),
       text: getMessageText(json),
       topicId: getChangeTopicId(json),
     };
@@ -133,6 +145,7 @@ const getFields = json => {
 
   if (contentType === 'photoPostBroadcast') {
     return {
+      attachments: getMessageAttachments(json),
       text: fields.text,
       topicId: getChangeTopicId(json),
     };
@@ -161,6 +174,7 @@ const getFields = json => {
 
   if (contentType === 'textPostBroadcast') {
     return {
+      attachments: getMessageAttachments(json),
       text: fields.text,
       topicId: getChangeTopicId(json),
     };

--- a/src/schema/gambitContent.js
+++ b/src/schema/gambitContent.js
@@ -18,8 +18,10 @@ const entryFields = `
 
 const broadcastFields = `
   ${entryFields}
-  "Broadcast message to send."
+  "Broadcast message text to send."
   text: String
+  "Broadcast message attachments to send."
+  attachments: [BroadcastMedia]
 `;
 
 /**
@@ -87,6 +89,14 @@ const typeDefs = gql`
     invalidText: String!
     "Template that confirms a text post was created. Replying to this creates another text post."
     completedTextPost: String!
+  }
+
+  "Media attached to a broadcast."
+  type BroadcastMedia {
+    "The broadcast media URL."
+    url: String!
+    "The broadcast media content type."
+    contentType: String!
   }
 
   "A DoSomething.org broadcast."


### PR DESCRIPTION
Each broadcast content type in Gambit Contentful has an `attachments` multi-value field.

Example request:
```
{
  broadcast(id:"2bb1xED8Hi86OqWMYuQYO2") {
    id
    name
    text
    attachments {
      url
      contentType
    }
  }
}
```

Example response:
```
{
  "data": {
    "broadcast": {
      "id": "2bb1xED8Hi86OqWMYuQYO2",
      "name": "FiveActionsChallenge2018_Signups_Day5_Reminder",
      "text": "Hey it's Freddie again! After a week of helping others, don't forget to celebrate yourself! Text START to send us a photo of you with your positive post-it notes for one more chance to win gift cards and the $5k scholarship.",
      "attachments": [
        {
          "url": "//images.ctfassets.net/owik07lyerdj/4w9fo1OzJ6OeMC8e44mCMy/2c9cfc67c95853e088249d34daa6d447/4016587-e1c2cfb50f39e7e1d9b794e75e9a38cc-1500061006.jpg",
          "contentType": "image/jpeg"
        }
      ]
    }
  }
}
```