### PR TITLE
Fix branch name for production deploys.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
             - deploy-qa
           filters:
             branches:
-              only: circleci-workflow
+              only: master
       - lambda/deploy:
           name: deploy-dev
           app: dosomething-graphql-dev

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,0 @@
-box: node
-
-build:
-  steps:
-    - npm-install
-    - npm-test


### PR DESCRIPTION
Whoops! I forgot to reset the branch filter for the `hold` job in #52.