### PR TITLE
Renames Gambit Conversations/Content

### DIFF
--- a/config/services.js
+++ b/config/services.js
@@ -20,6 +20,7 @@ const environments = {
   local: {
     displayName: 'local development',
 
+    // Contentful
     contentful,
 
     // Northstar
@@ -52,7 +53,7 @@ const environments = {
       // Note: Gambit doesn't have a dev instance, so we use QA.
       url: 'https://gambit-conversations-staging.herokuapp.com',
       user: process.env.QA_GAMBIT_BASIC_AUTH_USER,
-      pass: process.env.QA_GAMBIT_BAISC_AUTH_PASS,
+      pass: process.env.QA_GAMBIT_BASIC_AUTH_PASS,
     },
 
     // Northstar

--- a/config/services.js
+++ b/config/services.js
@@ -1,12 +1,12 @@
-/**
- * Gambit Content has a single environment used across all GraphQL environments.
- */
-const gambitContent = {
-  spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,
-  accessToken: process.env.GAMBIT_CONTENTFUL_ACCESS_TOKEN,
-  cache: {
-    name: 'gambitContent',
-    expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
+const contentful = {
+  // Gambit uses a single space/environment used across all GraphQL environments.
+  gambit: {
+    spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,
+    accessToken: process.env.GAMBIT_CONTENTFUL_ACCESS_TOKEN,
+    cache: {
+      name: 'gambitContent',
+      expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
+    },
   },
 };
 
@@ -19,6 +19,8 @@ const environments = {
    */
   local: {
     displayName: 'local development',
+
+    contentful,
 
     // Northstar
     northstar: {
@@ -42,13 +44,15 @@ const environments = {
   dev: {
     displayName: 'Development',
 
+    // Contentful
+    contentful,
+
     // Gambit
-    gambitContent,
-    gambitConversations: {
-      // Note: Conversations doesn't have a dev instance, so we use QA.
+    gambit: {
+      // Note: Gambit doesn't have a dev instance, so we use QA.
       url: 'https://gambit-conversations-staging.herokuapp.com',
-      user: process.env.QA_GAMBIT_CONVERSATIONS_USER,
-      pass: process.env.QA_GAMBIT_CONVERSATIONS_PASS,
+      user: process.env.QA_GAMBIT_BASIC_AUTH_USER,
+      pass: process.env.QA_GAMBIT_BAISC_AUTH_PASS,
     },
 
     // Northstar
@@ -73,13 +77,14 @@ const environments = {
   qa: {
     displayName: 'QA',
 
+    // Contentful
+    contentful,
+
     // Gambit
-    gambitContent,
-    gambitConversations: {
+    gambit: {
       url: 'https://gambit-conversations-staging.herokuapp.com',
-      // TODO: Validate requests with Northstar token instead of Gambit basic auth.
-      user: process.env.QA_GAMBIT_CONVERSATIONS_USER,
-      pass: process.env.QA_GAMBIT_CONVERSATIONS_PASS,
+      user: process.env.QA_GAMBIT_BASIC_AUTH_USER,
+      pass: process.env.QA_GAMBIT_BASIC_AUTH_PASS,
     },
 
     // Northstar
@@ -104,13 +109,14 @@ const environments = {
   production: {
     displayName: 'production',
 
+    // Contentful
+    contentful,
+
     // Gambit
-    gambitContent,
-    gambitConversations: {
+    gambit: {
       url: 'https://gambit-conversations-prod.herokuapp.com',
-      // TODO: Validate requests with Northstar token instead of Gambit basic auth.
-      user: process.env.PRODUCTION_GAMBIT_CONVERSATIONS_USER,
-      pass: process.env.PRODUCTION_GAMBIT_CONVERSATIONS_PASS,
+      user: process.env.PRODUCTION_GAMBIT_BASIC_AUTH_USER,
+      pass: process.env.PRODUCTION_GAMBIT_BASIC_AUTH_PASS,
     },
 
     // Northstar

--- a/src/loader.js
+++ b/src/loader.js
@@ -4,8 +4,8 @@ import DataLoader from 'dataloader';
 
 import { getCampaignById, getSignupsById } from './repositories/rogue';
 import { getUserById } from './repositories/northstar';
-import { getConversationById } from './repositories/gambitConversations';
-import { getGambitContentfulEntryById } from './repositories/gambitContent';
+import { getConversationById } from './repositories/gambit';
+import { getGambitContentfulEntryById } from './repositories/contentful/gambit';
 import { authorizedRequest } from './repositories/helpers';
 
 /**

--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -2,14 +2,14 @@ import { createClient } from 'contentful';
 import { assign, map } from 'lodash';
 import logger from 'heroku-logger';
 
-import config from '../../config';
-import Cache from '../cache';
+import config from '../../../config';
+import Cache from '../../cache';
 
-const cache = new Cache(config('services.gambitContent.cache'));
+const cache = new Cache(config('services.contentful.gambit.cache'));
 
 const contentfulClient = createClient({
-  space: config('services.gambitContent.spaceId'),
-  accessToken: config('services.gambitContent.accessToken'),
+  space: config('services.contentful.gambit.spaceId'),
+  accessToken: config('services.contentful.gambit.accessToken'),
 });
 
 /**
@@ -243,7 +243,7 @@ export const getGambitContentfulEntryById = async (id, context) => {
 };
 
 /**
- * Fetch all conversation triggers from Gambit Content.
+ * Fetch all conversation triggers from the Gambit Contentful space.
  *
  * @return {Array}
  */
@@ -272,7 +272,7 @@ export const getConversationTriggers = async () => {
 };
 
 /**
- * Fetch all web signup confirmations from Gambit Content.
+ * Fetch all web signup confirmations from the Gambit Contentful space.
  *
  * @return {Array}
  */

--- a/src/repositories/gambit.js
+++ b/src/repositories/gambit.js
@@ -4,24 +4,20 @@ import { map } from 'lodash';
 import config from '../../config';
 import { transformResponse } from './helpers';
 
-const GAMBIT_CONVERSATIONS_URL = config('services.gambitConversations.url');
-const GAMBIT_CONVERSATIONS_AUTH = `${config(
-  'services.gambitConversations.user',
-)}:${config('services.gambitConversations.pass')}`;
+const GAMBIT_URL = config('services.gambit.url');
+const GAMBIT_AUTH = `${config('services.gambit.user')}:${config(
+  'services.gambit.pass',
+)}`;
 
-// TODO: Add Northstar token support to Gambit Conversations, use helpers.authorizedRequest
 const authorizedRequest = () => ({
   headers: {
     Accept: 'application/json',
-    Authorization: `Basic ${Buffer.from(GAMBIT_CONVERSATIONS_AUTH).toString(
-      'base64',
-    )}`,
+    Authorization: `Basic ${Buffer.from(GAMBIT_AUTH).toString('base64')}`,
   },
 });
 
 /**
  * Transform an individual item response.
- * TODO: Modify Conversations API to return data object to deprecate this function.
  *
  * @param {Object} json
  * @return {Object}
@@ -30,7 +26,6 @@ export const transformItem = json => transformResponse(json);
 
 /**
  * Transform a collection response.
- * TODO: Modify Conversations API to return data object to deprecate this function.
  *
  * @param {Object} json
  * @return {Object}
@@ -57,7 +52,7 @@ export const getConversationById = async (id, context) => {
 
   try {
     const response = await fetch(
-      `${GAMBIT_CONVERSATIONS_URL}/api/v1/conversations/${id}`,
+      `${GAMBIT_URL}/api/v1/conversations/${id}`,
       authorizedRequest(context),
     );
 
@@ -83,7 +78,7 @@ export const getConversationById = async (id, context) => {
  */
 export const getConversations = async (args, context) => {
   const response = await fetch(
-    `${GAMBIT_CONVERSATIONS_URL}/api/v1/conversations`,
+    `${GAMBIT_URL}/api/v1/conversations`,
     authorizedRequest(context),
   );
 
@@ -103,7 +98,7 @@ export const getConversationsByUserId = async (args, context) => {
   logger.debug('Loading user conversations from Gambit', { id: userId });
 
   const response = await fetch(
-    `${GAMBIT_CONVERSATIONS_URL}/api/v1/conversations?query={"userId":"${
+    `${GAMBIT_URL}/api/v1/conversations?query={"userId":"${
       userId
     }"}&${getPaginationQueryString(args.page, args.count)}`,
     authorizedRequest(context),
@@ -125,7 +120,7 @@ export const getMessageById = async (id, context) => {
 
   try {
     const response = await fetch(
-      `${GAMBIT_CONVERSATIONS_URL}/api/v1/messages/${id}`,
+      `${GAMBIT_URL}/api/v1/messages/${id}`,
       authorizedRequest(context),
     );
 
@@ -149,7 +144,7 @@ export const getMessages = async (args, context) => {
   logger.debug('Loading messages from Gambit');
 
   const response = await fetch(
-    `${GAMBIT_CONVERSATIONS_URL}/api/v1/messages?${getPaginationQueryString(
+    `${GAMBIT_URL}/api/v1/messages?${getPaginationQueryString(
       args.page,
       args.count,
     )}`,
@@ -171,7 +166,7 @@ export const getMessagesByConversationId = async (id, page, count, context) => {
   logger.debug('Loading messages from Gambit for Conversation', { id });
 
   const response = await fetch(
-    `${GAMBIT_CONVERSATIONS_URL}/api/v1/messages?query={"conversationId":"${
+    `${GAMBIT_URL}/api/v1/messages?query={"conversationId":"${
       id
     }"}&${getPaginationQueryString(page, count)}`,
     authorizedRequest(context),

--- a/src/schema/contentful/gambit.js
+++ b/src/schema/contentful/gambit.js
@@ -4,8 +4,8 @@ import { gql } from 'apollo-server';
 import {
   getConversationTriggers,
   getWebSignupConfirmations,
-} from '../repositories/gambitContent';
-import Loader from '../loader';
+} from '../../repositories/contentful/gambit';
+import Loader from '../../loader';
 
 const entryFields = `
   "The entry ID."

--- a/src/schema/gambit.js
+++ b/src/schema/gambit.js
@@ -9,7 +9,7 @@ import {
   getMessageById,
   getMessages,
   getMessagesByConversationId,
-} from '../repositories/gambitConversations';
+} from '../repositories/gambit';
 
 /**
  * GraphQL types.
@@ -51,8 +51,6 @@ const typeDefs = gql`
     updatedAt: DateTime
     "The topic ID of the conversation topic when message was created."
     topicId: String
-    "The message text."
-    text: String
     "The message template (if outbound)."
     template: String
     "The Rivescript trigger that was matched."

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -4,8 +4,8 @@ import { mergeSchemas } from 'graphql-tools';
 // Schemas
 import rogueSchema from './rogue';
 import northstarSchema from './northstar';
-import gambitContentSchema from './gambitContent';
-import gambitConversationsSchema from './gambitConversations';
+import gambitContentfulSchema from './contentful/gambit';
+import gambitSchema from './gambit';
 
 /**
  * The schema used to link services together.
@@ -78,7 +78,7 @@ const linkResolvers = {
       fragment: 'fragment ConversationsFragment on User { id }',
       resolve(user, args, context, info) {
         return info.mergeInfo.delegateToSchema({
-          schema: gambitConversationsSchema,
+          schema: gambitSchema,
           operation: 'query',
           fieldName: 'conversationsByUserId',
           args: {
@@ -157,7 +157,7 @@ const linkResolvers = {
       fragment: 'fragment TopicFragment on Conversation { topicId }',
       resolve(conversation, args, context, info) {
         return info.mergeInfo.delegateToSchema({
-          schema: gambitContentSchema,
+          schema: gambitContentfulSchema,
           operation: 'query',
           fieldName: 'topic',
           args: {
@@ -189,7 +189,7 @@ const linkResolvers = {
       fragment: 'fragment TopicFragment on Message { topicId }',
       resolve(message, args, context, info) {
         return info.mergeInfo.delegateToSchema({
-          schema: gambitContentSchema,
+          schema: gambitContentfulSchema,
           operation: 'query',
           fieldName: 'topic',
           args: {
@@ -297,8 +297,8 @@ const schema = mergeSchemas({
   schemas: [
     northstarSchema,
     rogueSchema,
-    gambitConversationsSchema,
-    gambitContentSchema,
+    gambitContentfulSchema,
+    gambitSchema,
     linkSchema,
   ],
   resolvers: linkResolvers,


### PR DESCRIPTION
Renames `gambitConversations` to gambit per https://github.com/DoSomething/gambit/pull/470, renames `gambitContent` to `contentful/gambit`.  This PR requires updating config vars for Gambit conversations requests (which is only used by Gambit Admin).