### PR TITLE
Enable playground once we set NODE_ENV on production.

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ const server = new ApolloServer({
   schema,
   cacheControl: true, // Send 'Cache-Control' headers where needed.
   introspection: true, // Enable introspection in our production environment.
+  playground: true, // Enable playground on production for exploration & debugging.
   tracing: true, // Enable tracing on requests.
 });
 


### PR DESCRIPTION
This pull request sets `playground: true`, since by default this is disabled [in production](https://github.com/DoSomething/infrastructure/pull/148).