### PR TITLE
Adjust CORS settings.

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,8 +26,9 @@ exports.handler = function(event, context, callback) {
   // Enable CORS for cross-domain usage.
   const handlerSettings = {
     cors: {
-      origin: true,
+      origin: '*',
       credentials: true,
+      allowedHeaders: ['content-type'],
     },
   };
 


### PR DESCRIPTION
The CORS settings don't seem to be quite right when testing the new Lambda backend with Phoenix! I'm hoping these changes (accepting GraphQL requests from any domain (`*`), and whitelisting the `Content-Type` header) clear things up:

<img width="1122" alt="screen shot 2019-02-12 at 12 02 27 pm" src="https://user-images.githubusercontent.com/583202/52653581-320eb780-2ebe-11e9-9cda-47a6dcdf43e5.png">