### PR TITLE
Two more CORS fixes on Lambda.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,9 @@ workflows:
           app: dosomething-graphql-qa
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - lambda/deploy:
           name: deploy-production
           app: dosomething-graphql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,9 @@ workflows:
           app: dosomething-graphql-qa
           requires:
             - build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - lambda/deploy:
           name: deploy-production
           app: dosomething-graphql

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ exports.handler = function(event, context, callback) {
   // @TODO: Is this a bug with our API Gateway config?
   event.path = event.requestContext.path; // eslint-disable-line
 
+  console.log(event);
   // Enable CORS for cross-domain usage.
   const handlerSettings = {
     cors: {

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ const schema = require('./lib/src/schema').default;
 const server = new ApolloServer({
   schema,
   context: ({ event }) => ({
-    authorization: event.headers.authorization,
+    authorization: event.headers.Authorization,
   }),
   cacheControl: true, // Send 'Cache-Control' headers where needed.
   introspection: true, // Enable introspection in our production environment.

--- a/main.js
+++ b/main.js
@@ -10,6 +10,9 @@ const schema = require('./lib/src/schema').default;
 
 const server = new ApolloServer({
   schema,
+  context: ({ event }) => ({
+    authorization: event.headers.authorization,
+  }),
   cacheControl: true, // Send 'Cache-Control' headers where needed.
   introspection: true, // Enable introspection in our production environment.
   playground: true, // Enable playground on production for exploration & debugging.

--- a/main.js
+++ b/main.js
@@ -26,7 +26,6 @@ exports.handler = function(event, context, callback) {
   // @TODO: Is this a bug with our API Gateway config?
   event.path = event.requestContext.path; // eslint-disable-line
 
-  console.log(event);
   // Enable CORS for cross-domain usage.
   const handlerSettings = {
     cors: {

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ exports.handler = function(event, context, callback) {
     cors: {
       origin: '*',
       credentials: true,
-      allowedHeaders: ['content-type'],
+      allowedHeaders: ['content-type', 'authorization'],
     },
   };
 


### PR DESCRIPTION
Two more issues I ran into when testing this on Lambda:

🔑 I hadn't added the "auth" context (so even requests with this header were effectively anonymous).

🍭 Add `Authorization` to list of allowed headers on cross-origin requests.

I tested this out by temporarily lifting the restriction to only deploy `master` to QA. 😈 