### PR TITLE
Read HTML file as string.

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ const server = new ApolloServer({
   ...config('graphql'),
   schema,
   context: ({ event }) => ({
-    authorization: event.headers.Authorization,
+    authorization: event.headers.Authorization || event.headers.authorization,
   }),
 });
 
@@ -24,7 +24,7 @@ exports.handler = (event, context, callback) => {
   if (event.httpMethod === 'GET' && accept && accept.includes('text/html')) {
     return callback(null, {
       statusCode: 200,
-      body: fs.readFileSync(`${__dirname}/src/playground.html`),
+      body: fs.readFileSync(`${__dirname}/src/playground.html`, 'utf8'),
       headers: {
         'Content-Type': 'text/html',
       },


### PR DESCRIPTION
Whoops – I accidentally broke the playground view on Lambda in #62:

> (bc75fcb4-2fd1-11e9-88ad-0da6015d1c81) Execution failed due to configuration error: Malformed Lambda proxy response


This pull request adds the encoding to the `readFileSync` call so this doesn't get returned as a `Buffer` (rather than a string of HTML) and bork everything up. ✌️

I also added support for parsing lower-case `authorization` headers. Not sure how common this is, but saw it in the `apollo-server-lambda` source & seemed reasonable enough. 🤷‍♂️