### PR TITLE
Read from new GraphQL config file.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 
 import app from './app';
 import cache from './cache';
+import graphql from './graphql';
 import services from './services';
 
 /**
@@ -11,7 +12,7 @@ import services from './services';
  * @param {mixed} defaultValue
  */
 export default (key, defaultValue = null) => {
-  const config = { app, cache, services };
+  const config = { app, cache, graphql, services };
 
   return get(config, key, defaultValue);
 };


### PR DESCRIPTION
Whoops, one more issue – I hadn't noticed this config file wasn't getting read since we load similar defaults when `NODE_ENV` is not set to `production`. On our real instances however, we'd see server errors from `introspection` being disabled in prod by default. ⚠️

![screen shot 2019-02-13 at 4 19 24 pm](https://user-images.githubusercontent.com/583202/52744628-3e247300-2fab-11e9-9e09-ef3ee079e2ce.png)

With this change, the `config('graphql')` call form our entry points now return the expected settings.