### PR TITLE
Do not require a Northstar ID from Rogue

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -78,7 +78,7 @@ const typeDefs = gql`
     "The specific action being performed (or 'default' on a single-action campaign)."
     action: String!
     "The Northstar user ID of the user who created this post."
-    userId: String!
+    userId: String
     "The Rogue campaign ID this post was made for."
     campaignId: String
     "The attached media for this post."


### PR DESCRIPTION
### What's Changed

Changed `String!` to `String` when getting `userId` with a post from Rogue.

I tried to test this, but I'm getting an error from Rogue QA that I think is unrelated? It's a `500` error when trying to hit `https://activity-qa.dosomething.org/api/v3/posts/961764`. This is the query I was getting an error on:
```
{
  post(id: 961764) {
    campaignId
    text
    url
    userId
  }
}
```
I would have expected to get the first three fields, but not the last one.