### PR TITLE
Don't try to resolve user if not provided.

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -122,6 +122,10 @@ const linkResolvers = {
     user: {
       fragment: 'fragment UserFragment on Post { userId }',
       resolve(post, args, context, info) {
+        if (!post.userId) {
+          return null;
+        }
+
         return info.mergeInfo.delegateToSchema({
           schema: northstarSchema,
           operation: 'query',


### PR DESCRIPTION
For our new "anonymous" action types, we don't provide a user ID in public responses. However, our `user(id: String!)` query (reasonably) requires an ID. This pull request updates the `Post`'s `user` resolver to account for the special case (for now, unique to posts) where `userId` might be empty.