### PR TITLE
Add "Action" type & relationship to posts.

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -63,6 +63,29 @@ const typeDefs = gql`
     updatedAt: DateTime
   }
 
+  type Action {
+    "The unique ID for this action."
+    id: Int!
+    "The internal name for this action."
+    name: String
+    "Does this action count as a reportback?"
+    reportback: Boolean
+    "Does this action count as a civic action?"
+    civicAction: Boolean
+    "Does this action count as a scholarship entry?"
+    scholarshipEntry: Boolean
+    "Anonymous actions will not be attributed to a particular user in public galleries."
+    anonymous: Boolean
+    "The noun for this action, e.g. 'cards' or 'jeans'."
+    noun: String
+    "The verb for this action, e.g. 'donated' or 'created'."
+    verb: String
+    "The time when this action was originally created."
+    createdAt: DateTime
+    "The time when this action was last modified."
+    updatedAt: DateTime
+  }
+
   "A media resource on a post."
   type Media {
     "The image URL."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -106,7 +106,9 @@ const typeDefs = gql`
     "The type of action (e.g. 'photo', 'voterReg', or 'text')."
     type: String!
     "The specific action being performed (or 'default' on a single-action campaign)."
-    action: String!
+    action: String! @deprecated(reason: "Use 'actionDetails' relationship instead.")
+    "The specific action being performed."
+    actionDetails: Action
     "The Northstar user ID of the user who created this post."
     userId: String
     "The Rogue campaign ID this post was made for."
@@ -287,6 +289,7 @@ const resolvers = {
     url: (post, args) => urlWithQuery(post.media.url, args),
     text: post => post.media.text,
     status: post => post.status.toUpperCase().replace('-', '_'),
+    actionDetails: post => post.actionDetails.data,
     location: (post, { format }) => {
       switch (format) {
         case 'HUMAN_FORMAT':


### PR DESCRIPTION
This pull request adds the `Action` type to our schema, and hooks up the `actionDetails` relationship on posts (since unfortunately `action` was already [in use](https://user-images.githubusercontent.com/583202/53665884-a7a6b180-3c3a-11e9-8556-38e7dd874ebd.png)). This will be used to determine whether posts are "anonymized" in galleries (so as not to confuse admins) & to source noun/verb information:

<img width="1242" alt="screen shot 2019-03-01 at 3 51 15 pm" src="https://user-images.githubusercontent.com/583202/53665663-133c4f00-3c3a-11e9-9479-d20ac6cadb91.png">

I've also deprecated the existing `action` field (which can now be queried with `actionDetails { name }`). Once we've confirmed that we've moved everything to using the new `actionDetails` relationship, we can then always replace the string `action` with the `Action` type for cleanliness. :v:

References [#164214415](https://www.pivotaltracker.com/story/show/164214415).