### PR TITLE
Make sure email subscription topics work when `null`

### DIFF
--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -12,4 +12,18 @@ export const stringToEnum = string => {
   return string.toUpperCase().replace('-', '_');
 };
 
+/**
+ * Transform a list into a list of GraphQL-style enums.
+ *
+ * @param  {String} string
+ * @return {String}
+ */
+export const listToEnums = list => {
+  if (!list) {
+    return null;
+  }
+
+  return list.map(stringToEnum);
+};
+
 export default null;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -137,8 +137,8 @@ const resolvers = {
     role: user => stringToEnum(user.role),
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
-    emailSubscriptionTopics: user =>
-      user.emailSubscriptionTopics.map(stringToEnum),
+    emailSubscriptionTopics: user => user.emailSubscriptionTopics ?
+      user.emailSubscriptionTopics.map(stringToEnum) : null,
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -4,7 +4,7 @@ import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 
 import Loader from '../loader';
-import { stringToEnum } from './helpers';
+import { stringToEnum, listToEnums } from './helpers';
 
 /**
  * GraphQL types.
@@ -137,8 +137,7 @@ const resolvers = {
     role: user => stringToEnum(user.role),
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
-    emailSubscriptionTopics: user => user.emailSubscriptionTopics ?
-      user.emailSubscriptionTopics.map(stringToEnum) : null,
+    emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),


### PR DESCRIPTION
### What's Changed

🆘 Added new helper `listToEnums()` which takes a list and gives you back a list of enums. This can handle being passed `null`.

👨‍🔬 Use `listToEnums()` when resolving `emailSubscriptionTopics`.

I was originally going to use a ternary to accomplish this, but [I was running into all sorts of linting trouble.](https://dosomething.slack.com/archives/CAPHYCR8V/p1551476766013600)