### PR TITLE
Add 'actionId' filter to 'posts' query.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -58,7 +58,7 @@ export const getCampaigns = async (args, context) => {
  * Fetch posts from Rogue.
  *
  * @param {String} action
- * @param {String} actionId
+ * @param {String} actionIds
  * @param {String} campaignId
  * @param {Number} count
  * @param {Number} page

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -58,6 +58,7 @@ export const getCampaigns = async (args, context) => {
  * Fetch posts from Rogue.
  *
  * @param {String} action
+ * @param {String} actionId
  * @param {String} campaignId
  * @param {Number} count
  * @param {Number} page
@@ -70,6 +71,7 @@ export const getPosts = async (args, context) => {
   const queryString = stringify({
     filter: {
       action: args.action,
+      action_id: args.actionIds ? args.actionIds.join(',') : null,
       campaign_id: args.campaignId,
       northstar_id: args.userId,
       source: args.source,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -202,6 +202,8 @@ const typeDefs = gql`
     posts(
       "The action name to load posts for."
       action: String
+      "The action IDs to load posts for."
+      actionIds: [String]
       "# The campaign ID to load posts for."
       campaignId: String
       "# The post source to load posts for."


### PR DESCRIPTION
This pull request adds an `actionIds` argument to the `posts` query, which will allow us to query posts by one or more Action IDs when rendering galleries on non-campaign pages:

![screen shot 2019-03-04 at 5 06 40 pm](https://user-images.githubusercontent.com/583202/53766167-1df81d80-3ea0-11e9-8985-53c483326eab.png)
