### PR TITLE
Add mutation for `email_subscription_topics`

### DIFF
--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -13,8 +13,8 @@ export const authorizedRequest = context => {
 
   return {
     headers: {
-      'Accept': 'application/json',
-      'Authorization': context.authorization,
+      Accept: 'application/json',
+      Authorization: context.authorization,
       'Content-Type': 'application/json',
     },
   };

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -13,8 +13,9 @@ export const authorizedRequest = context => {
 
   return {
     headers: {
-      Accept: 'application/json',
-      Authorization: context.authorization,
+      'Accept': 'application/json',
+      'Authorization': context.authorization,
+      'Content-Type': 'application/json',
     },
   };
 };

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -34,11 +34,10 @@ export const getUserById = async (id, options) => {
 export const updateEmailSubscriptionTopics = async (id, emailSubscriptionTopics, options) => {
   logger.debug('Updating email_subscription_topics for user in Northstar', { id });
 
-  const lowerCaseTopics = emailSubscriptionTopics.toString().toLowerCase();
-  const body = {'email_subscription_topics': [lowerCaseTopics]};
+  const formattedTopics = emailSubscriptionTopics.toString().toLowerCase().split(',');
+  const body = {'email_subscription_topics': formattedTopics};
 
   try {
-    logger.debug(JSON.stringify(body));
     const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}`, {
       ...requireAuthorizedRequest(options),
       method: 'PUT',
@@ -46,8 +45,6 @@ export const updateEmailSubscriptionTopics = async (id, emailSubscriptionTopics,
     });
 
     const json = await response.json();
-
-    logger.debug(JSON.stringify(json));
 
     return transformItem(json);
   } catch (exception) {

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -1,7 +1,7 @@
 import logger from 'heroku-logger';
 
 import config from '../../config';
-import { transformItem } from './helpers';
+import { transformItem, requireAuthorizedRequest } from './helpers';
 
 const NORTHSTAR_URL = config('services.northstar.url');
 
@@ -20,6 +20,39 @@ export const getUserById = async (id, options) => {
   } catch (exception) {
     const error = exception.message;
     logger.warn('Unable to load user.', { id, error, options });
+  }
+
+  return null;
+};
+
+/**
+ * Toggle a reaction on Rogue.
+ *
+ * @param {Number} postId
+ * @return {Object}
+ */
+export const updateEmailSubscriptionTopics = async (id, emailSubscriptionTopics, options) => {
+  logger.debug('Updating email_subscription_topics for user in Northstar', { id });
+
+  const lowerCaseTopics = emailSubscriptionTopics.toString().toLowerCase();
+  const body = {'email_subscription_topics': [lowerCaseTopics]};
+
+  try {
+    logger.debug(JSON.stringify(body));
+    const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}`, {
+      ...requireAuthorizedRequest(options),
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+
+    const json = await response.json();
+
+    logger.debug(JSON.stringify(json));
+
+    return transformItem(json);
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to load user.', { id, error });
   }
 
   return null;

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -40,7 +40,7 @@ export const updateEmailSubscriptionTopics = async (
     id,
   });
 
-  var formattedTopics = emailSubscriptionTopics
+  let formattedTopics = emailSubscriptionTopics
     .toString()
     .toLowerCase()
     .split(',');

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -40,10 +40,16 @@ export const updateEmailSubscriptionTopics = async (
     id,
   });
 
-  const formattedTopics = emailSubscriptionTopics
+  var formattedTopics = emailSubscriptionTopics
     .toString()
     .toLowerCase()
     .split(',');
+
+  // If no email topics were passed, send an empty array
+  if (emailSubscriptionTopics.length < 1) {
+    formattedTopics = [];
+  }
+
   const body = { email_subscription_topics: formattedTopics };
 
   try {

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -26,9 +26,12 @@ export const getUserById = async (id, options) => {
 };
 
 /**
- * Toggle a reaction on Rogue.
+ * Update a user's email_subscription_topics in Northstar.
  *
- * @param {Number} postId
+ * @param {String} id
+ * @param {[EmailSubscriptionTopic]} emailSubscriptionTopics
+ * @param {Object} options
+ *
  * @return {Object}
  */
 export const updateEmailSubscriptionTopics = async (
@@ -40,15 +43,9 @@ export const updateEmailSubscriptionTopics = async (
     id,
   });
 
-  let formattedTopics = emailSubscriptionTopics
-    .toString()
-    .toLowerCase()
-    .split(',');
-
-  // If no email topics were passed, send an empty array
-  if (emailSubscriptionTopics.length < 1) {
-    formattedTopics = [];
-  }
+  const formattedTopics = emailSubscriptionTopics.map(value =>
+    value.toLowerCase(),
+  );
 
   const body = { email_subscription_topics: formattedTopics };
 
@@ -64,7 +61,7 @@ export const updateEmailSubscriptionTopics = async (
     return transformItem(json);
   } catch (exception) {
     const error = exception.message;
-    logger.warn('Unable to load user.', { id, error });
+    logger.warn('Unable to update email subscription topics.', { id, error });
   }
 
   return null;

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -31,11 +31,20 @@ export const getUserById = async (id, options) => {
  * @param {Number} postId
  * @return {Object}
  */
-export const updateEmailSubscriptionTopics = async (id, emailSubscriptionTopics, options) => {
-  logger.debug('Updating email_subscription_topics for user in Northstar', { id });
+export const updateEmailSubscriptionTopics = async (
+  id,
+  emailSubscriptionTopics,
+  options,
+) => {
+  logger.debug('Updating email_subscription_topics for user in Northstar', {
+    id,
+  });
 
-  const formattedTopics = emailSubscriptionTopics.toString().toLowerCase().split(',');
-  const body = {'email_subscription_topics': formattedTopics};
+  const formattedTopics = emailSubscriptionTopics
+    .toString()
+    .toLowerCase()
+    .split(',');
+  const body = { email_subscription_topics: formattedTopics };
 
   try {
     const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}`, {

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -5,6 +5,7 @@ import { GraphQLAbsoluteUrl } from 'graphql-url';
 
 import Loader from '../loader';
 import { stringToEnum, listToEnums } from './helpers';
+import { updateEmailSubscriptionTopics } from '../repositories/northstar.js'
 
 /**
  * GraphQL types.
@@ -125,6 +126,16 @@ const typeDefs = gql`
     "Get a user by ID."
     user(id: String!): User
   }
+
+  type Mutation {
+    "Update the list of newsletters a user is subscribed to."
+    updateEmailSubscriptionTopics(
+      "The user to update."
+      id: String!
+      "The newsletters the user should be subscribed to."
+      emailSubscriptionTopics: [EmailSubscriptionTopic]!
+    ): User!
+  }
 `;
 
 /**
@@ -145,6 +156,9 @@ const resolvers = {
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,
   AbsoluteUrl: GraphQLAbsoluteUrl,
+  Mutation: {
+    updateEmailSubscriptionTopics: (_, args, context) => updateEmailSubscriptionTopics(args.id, args.emailSubscriptionTopics, context),
+  },
 };
 
 /**

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -5,7 +5,7 @@ import { GraphQLAbsoluteUrl } from 'graphql-url';
 
 import Loader from '../loader';
 import { stringToEnum, listToEnums } from './helpers';
-import { updateEmailSubscriptionTopics } from '../repositories/northstar.js'
+import { updateEmailSubscriptionTopics } from '../repositories/northstar';
 
 /**
  * GraphQL types.
@@ -157,7 +157,12 @@ const resolvers = {
   DateTime: GraphQLDateTime,
   AbsoluteUrl: GraphQLAbsoluteUrl,
   Mutation: {
-    updateEmailSubscriptionTopics: (_, args, context) => updateEmailSubscriptionTopics(args.id, args.emailSubscriptionTopics, context),
+    updateEmailSubscriptionTopics: (_, args, context) =>
+      updateEmailSubscriptionTopics(
+        args.id,
+        args.emailSubscriptionTopics,
+        context,
+      ),
   },
 };
 


### PR DESCRIPTION
### Updates

🎧 Adds `'Content-Type': 'application/json'` to all requests using `authorizedRequest()`.

🔇 Adds `updateEmailSubscriptionTopics()` mutation to Northstar schema.

🎩 Adds `updateEmailSubscriptionTopics()` which is called when that mutation gets resolved. This is what makes the `PUT` request to Northstar to overwrite the user's `email_subscription_topics` with the values passed in the mutation.

### Examples

1. 
```
mutation {
  updateEmailSubscriptionTopics(id: "5c119e42fdce271a0529d632", emailSubscriptionTopics: []) {
    firstName
    email
    emailSubscriptionTopics
  }
}
```
results in:
```
{
  "data": {
    "updateEmailSubscriptionTopics": {
      "firstName": "Malcolm",
      "email": "test@dosomething.org",
      "emailSubscriptionTopics": null
    }
  },
  "extensions": {
    "cacheControl": {
      "version": 1,
      "hints": [
        {
          "path": [
            "updateEmailSubscriptionTopics"
          ],
          "maxAge": 0
        }
      ]
    }
  }
}
```

2. 
```
mutation {
  updateEmailSubscriptionTopics(id: "5c119e42fdce271a0529d632", emailSubscriptionTopics: [LIFESTYLE, ACTIONS]) {
    firstName
    email
    emailSubscriptionTopics
  }
}
```
results in:
```
{
  "data": {
    "updateEmailSubscriptionTopics": {
      "firstName": "Malcolm",
      "email": "test@dosomething.org",
      "emailSubscriptionTopics": [
        "LIFESTYLE",
        "ACTIONS"
      ]
    }
  },
  "extensions": {
    "cacheControl": {
      "version": 1,
      "hints": [
        {
          "path": [
            "updateEmailSubscriptionTopics"
          ],
          "maxAge": 0
        }
      ]
    }
  }
}
```


