### PR TITLE
Add Phoenix (Contentful) schema & resolver.

### DIFF
--- a/config/services.js
+++ b/config/services.js
@@ -1,4 +1,23 @@
+import { get } from 'lodash';
+
+const environmentMapping = {
+  local: 'dev',
+  dev: 'dev',
+  qa: 'qa',
+  master: 'master',
+};
+
 const contentful = {
+  phoenix: {
+    spaceId: process.env.PHOENIX_CONTENTFUL_SPACE_ID,
+    accessToken: process.env.PHOENIX_CONTENTFUL_ACCESS_TOKEN,
+    environment: get(environmentMapping, process.env.QUERY_ENV),
+    cache: {
+      name: 'phoenixContent',
+      expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
+    },
+  },
+
   // Gambit uses a single space/environment used across all GraphQL environments.
   gambit: {
     spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3365,7 +3365,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3389,13 +3390,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3412,19 +3415,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3555,7 +3561,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3569,6 +3576,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3585,6 +3593,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3593,13 +3602,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3620,6 +3631,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3708,7 +3720,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3722,6 +3735,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3817,7 +3831,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3859,6 +3874,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3880,6 +3896,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3928,13 +3945,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4149,6 +4168,11 @@
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
       }
+    },
+    "graphql-type-json": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.1.tgz",
+      "integrity": "sha1-0sF34vGxfYf4EHLNBTEcB1S6pCA="
     },
     "graphql-upload": {
       "version": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "graphql": "~14.0.0",
     "graphql-iso-date": "^3.5.0",
     "graphql-tools": "^4.0.3",
+    "graphql-type-json": "^0.2.1",
     "graphql-url": "^2.0.4",
     "heroku-logger": "^0.3.3",
     "lodash": "^4.17.10",

--- a/src/loader.js
+++ b/src/loader.js
@@ -5,6 +5,7 @@ import DataLoader from 'dataloader';
 import { getCampaignById, getSignupsById } from './repositories/rogue';
 import { getUserById } from './repositories/northstar';
 import { getConversationById } from './repositories/gambit';
+import { getPhoenixContentfulEntryById } from './repositories/contentful/phoenix';
 import { getGambitContentfulEntryById } from './repositories/contentful/gambit';
 import { authorizedRequest } from './repositories/helpers';
 
@@ -20,6 +21,9 @@ export default context => {
     logger.debug('Creating a new loader for this GraphQL request.');
     const options = authorizedRequest(context);
     set(context, 'loader', {
+      blocks: new DataLoader(ids =>
+        Promise.all(ids.map(id => getPhoenixContentfulEntryById(id))),
+      ),
       broadcasts: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulEntryById(id, options))),
       ),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -1,0 +1,62 @@
+import { createClient } from 'contentful';
+import logger from 'heroku-logger';
+
+import config from '../../../config';
+import Cache from '../../cache';
+
+const cache = new Cache(config('services.contentful.phoenix.cache'));
+
+const contentfulClient = createClient({
+  space: config('services.contentful.phoenix.spaceId'),
+  accessToken: config('services.contentful.phoenix.accessToken'),
+  environment: config('services.contentful.phoenix.environment'),
+});
+
+/**
+ * @param {Object} json
+ * @return {Object}
+ */
+const transformItem = json => ({
+  id: json.sys.id,
+  contentType: json.sys.contentType.sys.id,
+  createdAt: json.sys.createdAt,
+  updatedAt: json.sys.updatedAt,
+  ...json.fields,
+});
+
+/**
+ * Fetch a Phoenix Contentful entry by ID.
+ *
+ * @param {String} id
+ * @return {Object}
+ */
+export const getPhoenixContentfulEntryById = async id => {
+  logger.debug('Loading Phoenix Contentful entry', { id });
+
+  try {
+    const cachedEntry = await cache.get(id);
+
+    if (cachedEntry) {
+      logger.debug('Cache hit for Phoenix Contentful entry', { id });
+      return cachedEntry;
+    }
+
+    logger.debug('Cache miss for Phoenix Contentful entry', { id });
+
+    const json = await contentfulClient.getEntry(id);
+    const data = transformItem(json);
+    cache.set(id, data);
+
+    return data;
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to load Phoenix Contentful entry.', {
+      id,
+      error,
+    });
+  }
+
+  return null;
+};
+
+export default null;

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -50,10 +50,7 @@ export const getPhoenixContentfulEntryById = async id => {
     return data;
   } catch (exception) {
     const error = exception.message;
-    logger.warn('Unable to load Phoenix Contentful entry.', {
-      id,
-      error,
-    });
+    logger.warn('Unable to load Phoenix Contentful entry.', { id, error });
   }
 
   return null;

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -29,33 +29,53 @@ const typeDefs = gql`
   }
 
   type PostGallery implements Block {
+    "The internal-facing title for this gallery."
     internalTitle: String!
+    "The list of Rogue Action IDs to show in this gallery."
     actionIds: [Int]!
     ${entryFields}
   }
 
   type TextSubmissionAction implements Block {
+    "The internal-facing title for this text submission action."
     internalTitle: String!
+    "The Rogue Action ID that posts will be submitted for."
     actionId: Int
+    "Optional custom title of the text submission block."
     title: String
+    "Optional label for the text field, helping describe or prompt the user regarding what to submit."
     textFieldLabel: String
+    "Optional placeholder for the text field, providing an example of what a text submission should look like."
     textFieldPlaceholderMessage: String
+    "Optional custom text to display on the submission button."
     buttonText: String
+    "Optional content to display once the user successfully submits their petition reportback."
     affirmationContent: String
+    "Any custom overrides for this block."
     additionalContent: JSON
     ${entryFields}
   }
 
   type PetitionSubmissionAction implements Block {
+    "The internal-facing title for this photo submission action."
     internalTitle: String!
+    "The Rogue Action ID that posts will be submitted for."
     actionId: Int
+    "Optional custom title of the petition block."
     title: String
+    "The petition's content."
     content: String
+    "Optional custom placeholder for the petition message text field."
     textFieldPlaceholderMessage: String
+    "Optional custom text to display on the submission button."
     buttonText: String
+    "Optional custom title for the information block."
     informationTitle: String
+    "Optional custom content for the information block."
     informationContent: String
+    "Optional content to display once the user successfully submits their petition reportback."
     affirmationContent: String
+    "Any custom overrides for this block."
     additionalContent: JSON
     ${entryFields}
   }

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -49,6 +49,10 @@ const typeDefs = gql`
     textFieldPlaceholderMessage: String
     "Optional custom text to display on the submission button."
     buttonText: String
+    "Optional custom title for the information block."
+    informationTitle: String
+    "Optional custom content for the information block."
+    informationContent: String
     "Optional content to display once the user successfully submits their petition reportback."
     affirmationContent: String
     "Any custom overrides for this block."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -1,6 +1,7 @@
 import { makeExecutableSchema } from 'graphql-tools';
 import { GraphQLDateTime } from 'graphql-iso-date';
 import { upperFirst, camelCase } from 'lodash';
+import GraphQLJSON from 'graphql-type-json';
 import { gql } from 'apollo-server';
 
 import Loader from '../../loader';
@@ -20,6 +21,7 @@ const entryFields = `
  * @var {String}
  */
 const typeDefs = gql`
+  scalar JSON
   scalar DateTime
 
   interface Block {
@@ -27,9 +29,35 @@ const typeDefs = gql`
   }
 
   type PostGallery implements Block {
-    ${entryFields}
     internalTitle: String!
     actionIds: [Int]!
+    ${entryFields}
+  }
+
+  type TextSubmissionAction implements Block {
+    internalTitle: String!
+    actionId: Int
+    title: String
+    textFieldLabel: String
+    textFieldPlaceholderMessage: String
+    buttonText: String
+    affirmationContent: String
+    additionalContent: JSON
+    ${entryFields}
+  }
+
+  type PetitionSubmissionAction implements Block {
+    internalTitle: String!
+    actionId: Int
+    title: String
+    content: String
+    textFieldPlaceholderMessage: String
+    buttonText: String
+    informationTitle: String
+    informationContent: String
+    affirmationContent: String
+    additionalContent: JSON
+    ${entryFields}
   }
 
   type Query {
@@ -44,6 +72,7 @@ const typeDefs = gql`
  * @var {Object}
  */
 const resolvers = {
+  JSON: GraphQLJSON,
   DateTime: GraphQLDateTime,
   Query: {
     block: (_, args, context) => Loader(context).blocks.load(args.id),

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -31,7 +31,7 @@ const typeDefs = gql`
   type PostGallery implements Block {
     "The internal-facing title for this gallery."
     internalTitle: String!
-    "The list of Rogue Action IDs to show in this gallery."
+    "The list of Action IDs to show in this gallery."
     actionIds: [Int]!
     ${entryFields}
   }
@@ -39,7 +39,7 @@ const typeDefs = gql`
   type TextSubmissionAction implements Block {
     "The internal-facing title for this text submission action."
     internalTitle: String!
-    "The Rogue Action ID that posts will be submitted for."
+    "The Action ID that posts will be submitted for."
     actionId: Int
     "Optional custom title of the text submission block."
     title: String
@@ -59,7 +59,7 @@ const typeDefs = gql`
   type PetitionSubmissionAction implements Block {
     "The internal-facing title for this photo submission action."
     internalTitle: String!
-    "The Rogue Action ID that posts will be submitted for."
+    "The Action ID that posts will be submitted for."
     actionId: Int
     "Optional custom title of the petition block."
     title: String

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -1,0 +1,64 @@
+import { makeExecutableSchema } from 'graphql-tools';
+import { GraphQLDateTime } from 'graphql-iso-date';
+import { upperFirst, camelCase } from 'lodash';
+import { gql } from 'apollo-server';
+
+import Loader from '../../loader';
+
+const entryFields = `
+    "The Contentful ID for this block."
+    id: String!
+    "The time this entry was last modified."
+    updatedAt: DateTime
+    "The time when this entry was originally created."
+    createdAt: DateTime
+`;
+
+/**
+ * GraphQL types.
+ *
+ * @var {String}
+ */
+const typeDefs = gql`
+  scalar DateTime
+
+  interface Block {
+    ${entryFields}
+  }
+
+  type PostGallery implements Block {
+    ${entryFields}
+    internalTitle: String!
+    actionIds: [Int]!
+  }
+
+  type Query {
+    "Get a block by ID."
+    block(id: String!): Block
+  }
+`;
+
+/**
+ * GraphQL resolvers.
+ *
+ * @var {Object}
+ */
+const resolvers = {
+  DateTime: GraphQLDateTime,
+  Query: {
+    block: (_, args, context) => Loader(context).blocks.load(args.id),
+  },
+  Block: {
+    __resolveType: block => upperFirst(camelCase(block.contentType)),
+  },
+};
+
+/**
+ * The generated schema.
+ *
+ * @var {GraphQLSchema}
+ */
+export default makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -4,6 +4,7 @@ import { mergeSchemas } from 'graphql-tools';
 // Schemas
 import rogueSchema from './rogue';
 import northstarSchema from './northstar';
+import phoenixContentfulSchema from './contentful/phoenix';
 import gambitContentfulSchema from './contentful/gambit';
 import gambitSchema from './gambit';
 
@@ -301,6 +302,7 @@ const schema = mergeSchemas({
   schemas: [
     northstarSchema,
     rogueSchema,
+    phoenixContentfulSchema,
     gambitContentfulSchema,
     gambitSchema,
     linkSchema,


### PR DESCRIPTION
This pull request adds a bare-bones Phoenix schema and Contentful resolver, modeled based on how we fetch from Gambit's Contentful space. This will be used for the Story Page's embedded blocks.

![Screen Shot 2019-03-08 at 3 43 21 PM](https://user-images.githubusercontent.com/583202/54054745-05964480-41b9-11e9-85cf-0bab07b72842.png)

#### Why do this in the first place?
This should help start to unify how we handle data-fetching in Phoenix, which uses GraphQL for some things and our (sometimes brittle) PHP Content API for other things. It'll also provide a notable performance boost for the upcoming story page (which currently performs individual uncached requests for each embedded block).

We also want web campaigns to be [available for third-party usage](https://github.com/DoSomething/graphql/issues/55) in the future!

#### Why not use Contentful's own GraphQL implementation?
I'm still interested in this! In the interest of time, however, I think it's worth following the same pattern that Aaron pioneered with the Gambit Contentful space since we know how to do it & it's been tested under load in production. 

It's also very important to me that we can cache these requests & create "interfaces" for related content types (like blocks), neither of which are things Contentful has first-party support for (yet).

#### This isn't everything!
I know! I wanted to get an MVP out the door so we can use this for the "Prom For All" story page's rich text block embeds, and we have a lot of Contentful content types that aren't used there. If there's anything that makes sense in that context that I've missed, absolutely let me know!