### PR TITLE
Ensure empty action_id is not included in query string.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -71,7 +71,7 @@ export const getPosts = async (args, context) => {
   const queryString = stringify({
     filter: {
       action: args.action,
-      action_id: args.actionIds ? args.actionIds.join(',') : null,
+      action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
       northstar_id: args.userId,
       source: args.source,
@@ -81,6 +81,8 @@ export const getPosts = async (args, context) => {
     limit: args.count,
     pagination: 'cursor',
   });
+
+  logger.debug('Loading posts from Rogue.', { args, queryString });
 
   const response = await fetch(
     `${ROGUE_URL}/api/v3/posts/?${queryString}`,


### PR DESCRIPTION
This pull request fixes an issue where an empty `action_id` filter (e.g. `?filter[action_id]=&…`) was being included in requests to Rogue for the `posts()` query when an `action_id` was not provided. This was causing the Submission Gallery to disappear & breaking our Ghost Inspector monitors.

The "empty" query was included because [`qs.stringify`](https://github.com/ljharb/qs#stringifying) only excludes `undefined`, not `null`.

References #73 and [this Slack conversation](https://dosomething.slack.com/archives/C0YGXUE01/p1552314624000400).