### PR TITLE
Rename Phoenix types & add EmbedBlock, ImagesBlock, and Asset.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -1,8 +1,8 @@
 import { makeExecutableSchema } from 'graphql-tools';
 import { GraphQLDateTime } from 'graphql-iso-date';
-import { upperFirst, camelCase } from 'lodash';
 import GraphQLJSON from 'graphql-type-json';
 import { gql } from 'apollo-server';
+import { get } from 'lodash';
 
 import Loader from '../../loader';
 
@@ -28,7 +28,7 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type PostGallery implements Block {
+  type PostGalleryBlock implements Block {
     "The internal-facing title for this gallery."
     internalTitle: String!
     "The list of Action IDs to show in this gallery."
@@ -36,7 +36,7 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type TextSubmissionAction implements Block {
+  type TextSubmissionBlock implements Block {
     "The internal-facing title for this text submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
@@ -60,7 +60,7 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type PetitionSubmissionAction implements Block {
+  type PetitionSubmissionBlock implements Block {
     "The internal-facing title for this photo submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
@@ -91,6 +91,17 @@ const typeDefs = gql`
 `;
 
 /**
+ * Contentful type to GraphQL type mappings.
+ *
+ * @var {Object}
+ */
+const contentTypeMappings = {
+  petitionSubmissionAction: 'PetitionSubmissionBlock',
+  postGallery: 'PostGalleryBlock',
+  textSubmissionAction: 'TextSubmissionBlock',
+};
+
+/**
  * GraphQL resolvers.
  *
  * @var {Object}
@@ -102,7 +113,7 @@ const resolvers = {
     block: (_, args, context) => Loader(context).blocks.load(args.id),
   },
   Block: {
-    __resolveType: block => upperFirst(camelCase(block.contentType)),
+    __resolveType: block => get(contentTypeMappings, block.contentType),
   },
 };
 

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -71,7 +71,7 @@ const typeDefs = gql`
     "The internal-facing title for this gallery."
     internalTitle: String!
     "The list of Action IDs to show in this gallery."
-    actionIds: [Int]!
+    actionIds: [String]!
     ${entryFields}
   }
 
@@ -79,7 +79,7 @@ const typeDefs = gql`
     "The internal-facing title for this text submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
-    actionId: Int
+    actionId: String
     "Optional custom title of the text submission block."
     title: String
     "Optional label for the text field, helping describe or prompt the user regarding what to submit."
@@ -103,7 +103,7 @@ const typeDefs = gql`
     "The internal-facing title for this photo submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
-    actionId: Int
+    actionId: String
     "Optional custom title of the petition block."
     title: String
     "The petition's content."


### PR DESCRIPTION
This pull request adds Contentful's "Embed" and "Images Block" components to our GraphQL schema, so they can be loaded for the story page. In order to render the "Images Block", it also adds support for (linked) assets, including common Image API formatting options.

One gotcha I ran into while setting this up was that we already had an `Embed` type (whoops), for the embed itself! So instead of automatically resolving type names (which might conflict), this pull request adds an _explicit_ mapping for blocks (e.g. `embed` → `EmbedBlock`), and renames some existing entities in GraphQL so their role is clearer in the overall system.