### PR TITLE
Fix usage of URL for Node 8.x.

### DIFF
--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -1,5 +1,6 @@
 import { createClient } from 'contentful';
 import logger from 'heroku-logger';
+import { URL } from 'url';
 
 import { urlWithQuery } from '../helpers';
 import config from '../../../config';


### PR DESCRIPTION
Whoops – I hadn't been importing `URL` so this wasn't working once deployed. I think this is since I'm on Node 11.x on my machine, but Lambda is stuck in the 8.x days (and admittedly, like, I should be too for dev/prod parity but that's a problem for another day).