### PR TITLE
Make actionId types consistent in Phoenix blocks.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -71,7 +71,7 @@ const typeDefs = gql`
     "The internal-facing title for this gallery."
     internalTitle: String!
     "The list of Action IDs to show in this gallery."
-    actionIds: [String]!
+    actionIds: [Int]!
     ${entryFields}
   }
 
@@ -79,7 +79,7 @@ const typeDefs = gql`
     "The internal-facing title for this text submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
-    actionId: String
+    actionId: Int
     "Optional custom title of the text submission block."
     title: String
     "Optional label for the text field, helping describe or prompt the user regarding what to submit."
@@ -103,7 +103,7 @@ const typeDefs = gql`
     "The internal-facing title for this photo submission action."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
-    actionId: String
+    actionId: Int
     "Optional custom title of the petition block."
     title: String
     "The petition's content."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -203,7 +203,7 @@ const typeDefs = gql`
       "The action name to load posts for."
       action: String
       "The action IDs to load posts for."
-      actionIds: [String]
+      actionIds: [Int]
       "# The campaign ID to load posts for."
       campaignId: String
       "# The post source to load posts for."


### PR DESCRIPTION
This pull request implements a little fix [based on @mendelB's comment](
https://github.com/DoSomething/phoenix-next/pull/1319#discussion_r267104040) on DoSomething/phoenix-next#1319. Since we return the _actual_ [`Action.id`](https://github.com/DoSomething/graphql/blob/8876d8d5e3433a53b74309338a870c379551e508/src/schema/rogue.js#L67-L68) field as an `Int`, we should be consistent here.