### PR TITLE
Add itemsPerRow to PostGalleryBlock.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -72,6 +72,8 @@ const typeDefs = gql`
     internalTitle: String!
     "The list of Action IDs to show in this gallery."
     actionIds: [Int]!
+    "The maximum number of items in a single row when viewing the gallery in a large display."
+    itemsPerRow: Int
     ${entryFields}
   }
 


### PR DESCRIPTION
This pull request adds `itemsPerRow` to the `PostGalleryBlock`, used on the "prom" story gallery.

![Screen Shot 2019-03-20 at 2 38 23 PM](https://user-images.githubusercontent.com/583202/54710334-d4553700-4b1d-11e9-99e6-9b69b65bf783.png)

References [this Slack message](https://dosomething.slack.com/archives/C2BPA7M8F/p1553106724337800).