### PR TITLE
Add asset query to Phoenix schema.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -6,9 +6,12 @@ import { getEmbed } from './repositories/embed';
 import { getCampaignById, getSignupsById } from './repositories/rogue';
 import { getUserById } from './repositories/northstar';
 import { getConversationById } from './repositories/gambit';
-import { getPhoenixContentfulEntryById } from './repositories/contentful/phoenix';
 import { getGambitContentfulEntryById } from './repositories/contentful/gambit';
 import { authorizedRequest } from './repositories/helpers';
+import {
+  getPhoenixContentfulAssetById,
+  getPhoenixContentfulEntryById,
+} from './repositories/contentful/phoenix';
 
 /**
  * The data loader handles batching and caching the backend
@@ -22,6 +25,9 @@ export default context => {
     logger.debug('Creating a new loader for this GraphQL request.');
     const options = authorizedRequest(context);
     set(context, 'loader', {
+      assets: new DataLoader(ids =>
+        Promise.all(ids.map(id => getPhoenixContentfulAssetById(id))),
+      ),
       blocks: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id))),
       ),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -59,6 +59,37 @@ export const getPhoenixContentfulEntryById = async id => {
 };
 
 /**
+ * Fetch a Phoenix Contentful entry by ID.
+ *
+ * @param {String} id
+ * @return {Object}
+ */
+export const getPhoenixContentfulAssetById = async id => {
+  logger.debug('Loading Phoenix Contentful asset', { id });
+
+  try {
+    const cachedEntry = await cache.get(id);
+
+    if (cachedEntry) {
+      logger.debug('Cache hit for Phoenix Contentful asset', { id });
+      return cachedEntry;
+    }
+
+    logger.debug('Cache miss for Phoenix Contentful asset', { id });
+
+    const data = await contentfulClient.getAsset(id);
+    cache.set(id, data);
+
+    return data;
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to load Phoenix Contentful asset.', { id, error });
+  }
+
+  return null;
+};
+
+/**
  * Given a Contentful asset, create a URL using Contentful's
  * Image API and the given field arguments.
  *

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -45,6 +45,8 @@ const typeDefs = gql`
   }
 
   type Asset {
+    "The unique ID for this Contentful asset."
+    id: String!
     "Title for this asset."
     title: String
     "Description for this asset."
@@ -128,6 +130,8 @@ const typeDefs = gql`
   type Query {
     "Get a block by ID."
     block(id: String!): Block
+    "Get an asset by ID."
+    asset(id: String!): Asset
   }
 `;
 
@@ -155,8 +159,10 @@ const resolvers = {
   AbsoluteUrl: GraphQLAbsoluteUrl,
   Query: {
     block: (_, args, context) => Loader(context).blocks.load(args.id),
+    asset: (_, args, context) => Loader(context).assets.load(args.id),
   },
   Asset: {
+    id: asset => asset.sys.id,
     title: asset => asset.fields.title,
     description: asset => asset.fields.description,
     contentType: asset => asset.fields.file.contentType,


### PR DESCRIPTION
This pull request adds an `asset(id: "…")` query to our Contentful schema that returns, you guessed it, an `Asset` from Contentful. Like entries, these will be cached locally for performance & redundancy.

Refs [Pivotal ID #164712381](https://www.pivotaltracker.com/story/show/164712381).