### PR TITLE
Updating PostGallery schema.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -74,6 +74,8 @@ const typeDefs = gql`
     actionIds: [Int]!
     "The maximum number of items in a single row when viewing the gallery in a large display."
     itemsPerRow: Int
+    "A filter type which users can select to filter the gallery."
+    filterType: String
     ${entryFields}
   }
 


### PR DESCRIPTION
This PR updates the schema for contentful/phoenix to include the new `filterType` in the `PostGalleryBlock` type.

Question: I wasn't sure if I need to indicate that it can be a `String` or `Null`. It's not a required field so it can be left without a selection (esp since Contentful doesn't have default values on fields).