### PR TITLE
Add LinkBlock, PhotoSubmissionBlock, ShareBlock, and VoterRegistrationBlock.

### DIFF
--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -29,6 +29,17 @@ const transformItem = json => ({
 });
 
 /**
+ * @param {Object} json
+ * @return {Object}
+ */
+const transformAsset = json => ({
+  id: json.sys.id,
+  createdAt: json.sys.createdAt,
+  updatedAt: json.sys.updatedAt,
+  ...json.fields,
+});
+
+/**
  * Fetch a Phoenix Contentful entry by ID.
  *
  * @param {String} id
@@ -79,7 +90,8 @@ export const getPhoenixContentfulAssetById = async id => {
 
     logger.debug('Cache miss for Phoenix Contentful asset', { id });
 
-    const data = await contentfulClient.getAsset(id);
+    const json = await contentfulClient.getAsset(id);
+    const data = transformAsset(json);
     cache.set(id, data);
 
     return data;
@@ -129,7 +141,7 @@ export const linkResolver = (entry, _, context, info) => {
  * @return {String}
  */
 export const createImageUrl = (asset, args) => {
-  const path = asset.fields.file.url;
+  const path = asset.file.url;
   if (!path) {
     return null;
   }

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -142,7 +142,7 @@ export const linkResolver = (entry, _, context, info) => {
     return link.map(asset => getPhoenixContentfulItemByLink(asset, context));
   }
 
-  return getPhoenixContentfulItemByLink(link);
+  return getPhoenixContentfulItemByLink(link, context);
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -6,7 +6,10 @@ import { gql } from 'apollo-server';
 import { get } from 'lodash';
 
 import Loader from '../../loader';
-import { createImageUrl } from '../../repositories/contentful/phoenix';
+import {
+  createImageUrl,
+  linkResolver,
+} from '../../repositories/contentful/phoenix';
 
 const entryFields = `
     "The Contentful ID for this block."
@@ -266,6 +269,12 @@ const resolvers = {
   },
   Block: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
+  },
+  ShareBlock: {
+    affirmationBlock: linkResolver,
+  },
+  LinkBlock: {
+    affiliateLogo: linkResolver,
   },
 };
 

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -261,10 +261,6 @@ const resolvers = {
     asset: (_, args, context) => Loader(context).assets.load(args.id),
   },
   Asset: {
-    id: asset => asset.sys.id,
-    title: asset => asset.fields.title,
-    description: asset => asset.fields.description,
-    contentType: asset => asset.fields.file.contentType,
     url: (asset, args) => createImageUrl(asset, args),
   },
   Block: {

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -149,6 +149,8 @@ const typeDefs = gql`
     socialPlatform: [String]
     "Optional description of the link."
     content: String
+    "The URL being linked to."
+    link: AbsoluteUrl
     "This will hide the link preview 'embed' on the share action."
     hideEmbed: Boolean
     "This block should be displayed in a modal after a successful share."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -81,6 +81,82 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type LinkBlock implements Block {
+    "The internal-facing title for this link block."
+    internalTitle: String!
+    "The user-facing title for this link block."
+    title: String
+    "Optional description of the link."
+    content: String
+    "The URL being linked to."
+    link: AbsoluteUrl
+    "Optional custom text to display on the submission button."
+    buttonText: String
+    "The logo of the partner or sponsor for this link action."
+    affiliateLogo: Asset
+    "The template to be used for this link action."
+    template: String
+    "Any custom overrides for this block."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
+  type PhotoSubmissionBlock implements Block {
+    "The internal-facing title for this photo submission action."
+    internalTitle: String!
+    "The Action ID that posts will be submitted for."
+    actionId: Int
+    "Optional custom title of the text submission block."
+    title: String
+    "Optional label for the caption field, helping describe or prompt the user regarding what to submit."
+    captionFieldLabel: String
+    "Optional placeholder for the caption field, providing an example of what a text submission should look like."
+    captionFieldPlaceholderMessage: String
+    "Should the form ask for the quantity of items in member's photo submission?"
+    showQuantityField: Boolean
+    "Optional label for the quantity field."
+    quantityFieldLabel: String
+    "Optional placeholder for the quantity field."
+    quantityFieldPlaceholder: String
+    "Optional label for the 'why participated' field."
+    whyParticipatedFieldLabel: String
+    "Optional placeholder for the 'why participated' field."
+    whyParticipatedFieldPlaceholder: String
+    "Optional custom text to display on the submission button."
+    buttonText: String
+    "Optional custom title for the information block."
+    informationTitle: String
+    "Optional custom content for the information block."
+    informationContent: String
+    "Optional content to display once the user successfully submits their petition reportback."
+    affirmationContent: String
+    "Any custom overrides for this block."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
+  type ShareBlock implements Block {
+    "The internal-facing title for this text submission action."
+    internalTitle: String!
+    "The Action ID that 'share' posts will be submitted for."
+    actionId: Int
+    "The user-facing title for this share block."
+    title: String
+    "The social platform that should be offered for sharing this link."
+    socialPlatform: [String]
+    "Optional description of the link."
+    content: String
+    "This will hide the link preview 'embed' on the share action."
+    hideEmbed: Boolean
+    "This block should be displayed in a modal after a successful share."
+    affirmationBlock: Block
+    "A quick text-only affirmation message. Ignored if an affirmation block is set."
+    affirmation: String
+    "Any custom overrides for this block."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
   type TextSubmissionBlock implements Block {
     "The internal-facing title for this text submission action."
     internalTitle: String!
@@ -129,6 +205,20 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type VoterRegistrationBlock implements Block {
+    "The internal-facing title for this photo submission action."
+    internalTitle: String!
+    "The user-facing title for this share block."
+    title: String
+    "The voter registration block's text content."
+    content: String
+    "The link to the appropriate Instapage or partner flow."
+    link: AbsoluteUrl
+    "Any custom overrides for this block."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
   type Query {
     "Get a block by ID."
     block(id: String!): Block
@@ -145,9 +235,13 @@ const typeDefs = gql`
 const contentTypeMappings = {
   embed: 'EmbedBlock',
   imagesBlock: 'ImagesBlock',
+  linkAction: 'LinkBlock',
   petitionSubmissionAction: 'PetitionSubmissionBlock',
+  photoSubmissionAction: 'PhotoSubmissionBlock',
   postGallery: 'PostGalleryBlock',
+  shareAction: 'ShareBlock',
   textSubmissionAction: 'TextSubmissionBlock',
+  voterRegistrationAction: 'VoterRegistrationBlock',
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -272,6 +272,9 @@ const resolvers = {
   LinkBlock: {
     affiliateLogo: linkResolver,
   },
+  ImagesBlock: {
+    images: linkResolver,
+  },
 };
 
 /**


### PR DESCRIPTION
This pull request adds some more content types from our Phoenix space that we may want to include on a story page (or anywhere) in the future – [LinkBlock](https://user-images.githubusercontent.com/583202/54851943-ccce9300-4cc1-11e9-85a8-2849b7b30669.png), [PhotoSubmissionBlock](https://user-images.githubusercontent.com/583202/54852961-c392f580-4cc4-11e9-9c85-0f31f0947eee.png), [ShareBlock](https://user-images.githubusercontent.com/583202/54845727-89b7f400-4cb0-11e9-9203-e960b29b2ffd.png), and [VoterRegistrationBlock](https://user-images.githubusercontent.com/583202/54853022-f4732a80-4cc4-11e9-90d8-392917c0b5ca.png).

This pull request also includes support for resolving linked content within entities (e.g. the `affirmationBlock` field on `ShareBlock`) & resolves linked assets from cache if available.