### PR TITLE
Adding location to Rogue Schema and Repository.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -61,6 +61,7 @@ export const getCampaigns = async (args, context) => {
  * @param {String} actionIds
  * @param {String} campaignId
  * @param {Number} count
+ * @param {String} location
  * @param {Number} page
  * @param {String} source
  * @param {String} type
@@ -73,6 +74,7 @@ export const getPosts = async (args, context) => {
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
+      location: args.location,
       northstar_id: args.userId,
       source: args.source,
       type: args.type,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -206,6 +206,8 @@ const typeDefs = gql`
       actionIds: [Int]
       "# The campaign ID to load posts for."
       campaignId: String
+      "The location to load posts for."
+      location: String
       "# The post source to load posts for."
       source: String
       "# The type name to load posts for."


### PR DESCRIPTION
This PR exposes `location` to the schema and adds it to the Rogue repository as an option when fetching posts.

Refs [PivotalTracker ID #164737236](https://www.pivotaltracker.com/story/show/164737236)