### PR TITLE
bugfix: make 4th and 5th optional choices in askMultipleChoice topic

### DIFF
--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -34,7 +34,7 @@ const getActionId = json => json.fields.actionId;
  * @return {String}
  */
 const getChangeTopicId = json => {
-  if (json.fields.topic) {
+  if (json && json.fields.topic) {
     return json.fields.topic.sys.id;
   }
   return null;
@@ -50,7 +50,12 @@ const getContentType = json => json.sys.contentType.sys.id;
  * @param {Object} json
  * @return {String}
  */
-const getMessageText = json => json.fields.text;
+const getMessageText = json => {
+  if (json && json.fields) {
+    return json.fields.text;
+  }
+  return null;
+};
 
 /**
  * @param {Object} json

--- a/src/schema/contentful/gambit.js
+++ b/src/schema/contentful/gambit.js
@@ -297,10 +297,26 @@ const resolvers = {
       Loader(context).topics.load(topic.saidSecondChoiceTopicId, context),
     saidThirdChoiceTopic: (topic, args, context) =>
       Loader(context).topics.load(topic.saidThirdChoiceTopicId, context),
-    saidFourthChoiceTopic: (topic, args, context) =>
-      Loader(context).topics.load(topic.saidFourthChoiceTopicId, context),
-    saidFifthChoiceTopic: (topic, args, context) =>
-      Loader(context).topics.load(topic.saidFifthChoiceTopicId, context),
+    /**
+     * This is the easiest way to prevent sending en empty value to the loader,
+     * which would end up in an exception. Ideally, I think we should create a local
+     * loading function that is aware of optional fields.
+     */
+    saidFourthChoiceTopic: (topic, args, context) => {
+      if (!topic.saidFourthChoiceTopicId) {
+        return null;
+      }
+      return Loader(context).topics.load(
+        topic.saidFourthChoiceTopicId,
+        context,
+      );
+    },
+    saidFifthChoiceTopic: (topic, args, context) => {
+      if (!topic.saidFifthChoiceTopicId) {
+        return null;
+      }
+      return Loader(context).topics.load(topic.saidFifthChoiceTopicId, context);
+    },
   },
   AskSubscriptionStatusBroadcastTopic: {
     saidActiveTopic: (topic, args, context) =>


### PR DESCRIPTION
# What's this PR do?
It fixes the bug introduced in #88 where it will expect 4th and 5th options to be required by optimistically inspecting the option's transition entry fields and running into TypeErrors.