### PR TITLE
Update PostGalleryBlock Schema

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -81,6 +81,8 @@ const typeDefs = gql`
     itemsPerRow: Int
     "A filter type which users can select to filter the gallery."
     filterType: String
+    "Hide the post reactions for this gallery"
+    hideReactions: Boolean
     ${entryFields}
   }
 


### PR DESCRIPTION
This PR adds the `hideReactions` field to the `PostGalleryBlock` Contentful/Phoenix block.

Based on updates in https://github.com/DoSomething/phoenix-next/pull/1343