### PR TITLE
conversationTriggers topic id for askMultipleChoice broadcasts.

### DIFF
--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -173,18 +173,13 @@ const getFields = json => {
 
   if (contentType === 'defaultTopicTrigger') {
     // The askMultipleChoice broadcast id is the topic we want to switch the member to
-    const multipleChoiceTopicId = fields.response.fields.firstChoiceTransition
-      ? fields.response.sys.id
-      : null;
+    const multipleChoiceTopicId =
+      getContentType(fields.response) === 'askMultipleChoice'
+        ? fields.response.sys.id
+        : null;
     const changeTopicId = fields.response.fields.topic
       ? fields.response.fields.topic.sys.id
       : null;
-
-    console.log({
-      trigger: fields.trigger,
-      reply: fields.response.fields.text,
-      topicId: multipleChoiceTopicId || changeTopicId,
-    });
 
     return {
       trigger: fields.trigger,

--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -172,12 +172,24 @@ const getFields = json => {
   }
 
   if (contentType === 'defaultTopicTrigger') {
+    // The askMultipleChoice broadcast id is the topic we want to switch the member to
+    const multipleChoiceTopicId = fields.response.fields.firstChoiceTransition
+      ? fields.response.sys.id
+      : null;
+    const changeTopicId = fields.response.fields.topic
+      ? fields.response.fields.topic.sys.id
+      : null;
+
+    console.log({
+      trigger: fields.trigger,
+      reply: fields.response.fields.text,
+      topicId: multipleChoiceTopicId || changeTopicId,
+    });
+
     return {
       trigger: fields.trigger,
       reply: fields.response.fields.text,
-      topicId: fields.response.fields.topic
-        ? fields.response.fields.topic.sys.id
-        : null,
+      topicId: multipleChoiceTopicId || changeTopicId,
     };
   }
 


### PR DESCRIPTION
# What's this PR do?

It let's content editors choose an `askMultipleChoice` content type as the "response" in `defaultTopicTrigger` content types. Typically, the "response" field points to content types that contain a "topic" field. In the case of `askMultipleChoice`, we would not have a "topic" field, so we need to use the broadcast's id as the topic id. This PR adds the logic to handle that.