### PR TITLE
Add previewImage field to EmbedBlock type

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -69,6 +69,8 @@ const typeDefs = gql`
   type EmbedBlock implements Block {
     "The URL of the content to be embedded."
     url: String!
+    "A preview image of the embed content. If set, replaces the embed on smaller screens."
+    previewImage: Asset
     ${entryFields}
   }
 


### PR DESCRIPTION
This PR adds a new `previewImage` field to the `EmbedBlock` type in `contentful/pheonix`.
(As per the added field over in https://github.com/DoSomething/phoenix-next/pull/1359)