### PR TITLE
Add LinkResolver for Embed Block previewImage

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -283,6 +283,9 @@ const resolvers = {
   ImagesBlock: {
     images: linkResolver,
   },
+  EmbedBlock: {
+    previewImage: linkResolver,
+  },
 };
 
 /**


### PR DESCRIPTION
This PR sets a `linkResolver` for the `EmbedBlock`s `previewImage` field.

Quick patch for #94 