### PR TITLE
Add a simple Lambda for clearing cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
             - deploy-qa
           filters:
             branches:
-              only: contentful-cache-clear
+              only: master
       - lambda/deploy:
           name: deploy-dev
           app: dosomething-graphql-dev-webhook
@@ -50,7 +50,7 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: contentful-cache-clear
       - lambda/deploy:
           name: deploy-qa
           app: dosomething-graphql-qa-webhook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,15 @@ workflows:
       - hold:
           type: approval
           requires:
-            - deploy-dev
-            - deploy-qa
+            - deploy-app-dev
+            - deploy-webhook-dev
+            - deploy-app-qa
+            - deploy-webhook-qa
           filters:
             branches:
               only: master
       - lambda/deploy:
-          name: deploy-dev
+          name: deploy-app-dev
           app: dosomething-graphql-dev
           requires:
             - build
@@ -52,7 +54,7 @@ workflows:
             branches:
               only: contentful-cache-clear
       - lambda/deploy:
-          name: deploy-dev
+          name: deploy-webhook-dev
           app: dosomething-graphql-dev-webhook
           requires:
             - build
@@ -60,7 +62,7 @@ workflows:
             branches:
               only: contentful-cache-clear
       - lambda/deploy:
-          name: deploy-qa
+          name: deploy-app-qa
           app: dosomething-graphql-qa
           requires:
             - build
@@ -68,7 +70,7 @@ workflows:
             branches:
               only: contentful-cache-clear
       - lambda/deploy:
-          name: deploy-qa
+          name: deploy-webhook-qa
           app: dosomething-graphql-qa-webhook
           requires:
             - build
@@ -76,8 +78,16 @@ workflows:
             branches:
               only: contentful-cache-clear
       - lambda/deploy:
-          name: deploy-production
+          name: deploy-app-production
           app: dosomething-graphql
+          requires:
+            - hold
+          filters:
+            branches:
+              only: master
+      - lambda/deploy:
+          name: deploy-webhook-production
+          app: dosomething-graphql-webhook
           requires:
             - hold
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ workflows:
             - deploy-qa
           filters:
             branches:
-              only: master
+              only: contentful-cache-clear
       - lambda/deploy:
           name: deploy-dev
-          app: dosomething-graphql-dev
+          app: dosomething-graphql-dev-webhook
           requires:
             - build
           filters:
@@ -53,12 +53,12 @@ workflows:
               only: master
       - lambda/deploy:
           name: deploy-qa
-          app: dosomething-graphql-qa
+          app: dosomething-graphql-qa-webhook
           requires:
             - build
           filters:
             branches:
-              only: master
+              only: contentful-cache-clear
       - lambda/deploy:
           name: deploy-production
           app: dosomething-graphql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,23 @@ workflows:
               only: master
       - lambda/deploy:
           name: deploy-dev
+          app: dosomething-graphql-dev
+          requires:
+            - build
+          filters:
+            branches:
+              only: contentful-cache-clear
+      - lambda/deploy:
+          name: deploy-dev
           app: dosomething-graphql-dev-webhook
+          requires:
+            - build
+          filters:
+            branches:
+              only: contentful-cache-clear
+      - lambda/deploy:
+          name: deploy-qa
+          app: dosomething-graphql-qa
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ workflows:
             - build
           filters:
             branches:
-              only: contentful-cache-clear
+              only: master
       - lambda/deploy:
           name: deploy-webhook-dev
           app: dosomething-graphql-dev-webhook
@@ -60,7 +60,7 @@ workflows:
             - build
           filters:
             branches:
-              only: contentful-cache-clear
+              only: master
       - lambda/deploy:
           name: deploy-app-qa
           app: dosomething-graphql-qa
@@ -68,7 +68,7 @@ workflows:
             - build
           filters:
             branches:
-              only: contentful-cache-clear
+              only: master
       - lambda/deploy:
           name: deploy-webhook-qa
           app: dosomething-graphql-qa-webhook
@@ -76,7 +76,7 @@ workflows:
             - build
           filters:
             branches:
-              only: contentful-cache-clear
+              only: master
       - lambda/deploy:
           name: deploy-app-production
           app: dosomething-graphql

--- a/config/cache.js
+++ b/config/cache.js
@@ -21,4 +21,11 @@ export default {
    * @type {String}
    */
   table: process.env.DYNAMODB_TABLE,
+
+  /**
+   * The secret key for clearing cache via a webhook.
+   *
+   * @type {String}
+   */
+  secret: process.env.WEBHOOK_SECRET,
 };

--- a/config/services.js
+++ b/config/services.js
@@ -10,6 +10,13 @@ const environmentMapping = {
 };
 
 const contentful = {
+  // Global Contentful cache. This should be used for any spaces
+  // that have a webhook enabled for cache clearing.
+  cache: {
+    name: 'contentful',
+    expiresIn: 24 * 3600 * 1000, // 24 hours (3600 seconds per hour).
+  },
+
   phoenix: {
     spaceId: process.env.PHOENIX_CONTENTFUL_SPACE_ID,
     accessToken: process.env.PHOENIX_CONTENTFUL_ACCESS_TOKEN,

--- a/src/cache.js
+++ b/src/cache.js
@@ -72,6 +72,8 @@ export default class {
       await this.client.start();
     }
 
+    logger.debug('Clearing cache key.', { key: `${this.name}:${key}` });
+
     return this.policy.drop(`${this.name}:${key}`);
   }
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -72,8 +72,6 @@ export default class {
       await this.client.start();
     }
 
-    logger.debug('Clearing cache key.', { key: `${this.name}:${key}` });
-
     return this.policy.drop(`${this.name}:${key}`);
   }
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -63,6 +63,19 @@ export default class {
   }
 
   /**
+   * Remove the given key from the cache.
+   * @param {String} key
+   * @param {*} value
+   */
+  async forget(key) {
+    if (!this.policy.isReady()) {
+      await this.client.start();
+    }
+
+    return this.policy.drop(`${this.name}:${key}`);
+  }
+
+  /**
    * Get an item from the cache, or run the callback
    * to fetch it and then store the result.
    *

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -7,9 +7,11 @@ import config from '../../../config';
 import Loader from '../../loader';
 import Cache from '../../cache';
 
-const cache = new Cache(config('services.contentful.phoenix.cache'));
+const cache = new Cache(config('services.contentful.cache'));
+const spaceId = config('services.contentful.phoenix.spaceId');
+
 const contentfulSpaceConfig = {
-  space: config('services.contentful.phoenix.spaceId'),
+  space: spaceId,
   environment: config('services.contentful.phoenix.environment'),
   resolveLinks: false,
 };
@@ -67,7 +69,7 @@ export const getPhoenixContentfulEntryById = async (id, context) => {
   }
 
   // Otherwise, read from cache or Contentful's Content API:
-  return cache.remember(id, async () => {
+  return cache.remember(`Entry:${spaceId}:${id}`, async () => {
     try {
       const json = await contentApi.getEntry(id);
       return transformItem(json);
@@ -101,7 +103,7 @@ export const getPhoenixContentfulAssetById = async (id, context) => {
   }
 
   // Otherwise, read from cache or Contentful's Content API:
-  return cache.remember(id, async () => {
+  return cache.remember(`Asset:${spaceId}:${id}`, async () => {
     try {
       const json = await contentApi.getAsset(id);
       return transformAsset(json);

--- a/webhook.js
+++ b/webhook.js
@@ -7,7 +7,7 @@
 const logger = require('heroku-logger');
 
 const config = require('./lib/config').default;
-const Cache = require('./lib/cache').default;
+const Cache = require('./lib/src/cache').default;
 
 // A simple helper for building a Lambda response.
 const response = (body, statusCode = 200) => ({ statusCode, body });

--- a/webhook.js
+++ b/webhook.js
@@ -38,7 +38,9 @@ exports.handler = async event => {
 
   const id = body.sys.id;
   try {
-    cache.forget(id);
+    logger.info('Clearing cache via Contentful webhook.', { id });
+
+    await cache.forget(id);
 
     logger.info('Cleared cache via Contentful webhook.', { id });
   } catch (exception) {

--- a/webhook.js
+++ b/webhook.js
@@ -1,0 +1,44 @@
+//
+// This is our AWS Lambda entry point for Contentful's
+// webhooks. We use this to automatically clear cache
+// on entries that have changed.
+//
+
+const logger = require('heroku-logger');
+
+const config = require('./lib/config').default;
+const Cache = require('./lib/cache').default;
+
+// A simple helper for building a Lambda response.
+const response = (body, statusCode = 200) => ({ statusCode, body });
+
+// The Lambda  'webhook.handler' function:
+exports.handler = async event => {
+  // @TODO: Should this live in an API Gateway authorizer instead?
+  if (event.headers['X-Contentful-Webhook-Key'] !== config('cache.secret')) {
+    logger.warn('Invalid API key provided to cache clear endpoint');
+    return response('Invalid API key.', 401);
+  }
+
+  if (event.body === null || event.body === undefined) {
+    return response('Invalid format.', 422);
+  }
+
+  // Validate the request format.
+  const body = JSON.parse(event.body);
+  const expectedFormat = body && body.sys && body.sys.id;
+  if (!expectedFormat) {
+    logger.error('Got unexpected webhook payload', { body });
+    return response('Invalid format.', 422);
+  }
+
+  // Clear cache for the specified ID from the Phoenix cache.
+  // @TODO: Determine which cache to use based on provided space ID.
+  const cache = new Cache(config('services.contentful.phoenix.cache'));
+
+  const id = body.sys.id;
+  cache.forget(id);
+
+  logger.info('Cleared cache via Contentful webhook.', { id });
+  return response('Success.', 200);
+};

--- a/webhook.js
+++ b/webhook.js
@@ -37,8 +37,17 @@ exports.handler = async event => {
   const cache = new Cache(config('services.contentful.phoenix.cache'));
 
   const id = body.sys.id;
-  cache.forget(id);
+  try {
+    cache.forget(id);
 
-  logger.info('Cleared cache via Contentful webhook.', { id });
+    logger.info('Cleared cache via Contentful webhook.', { id });
+  } catch (exception) {
+    console.log(exception);
+    logger.error('Could not remove from cache.', {
+      id,
+      error: exception.message,
+    });
+  }
+
   return response('Success.', 200);
 };


### PR DESCRIPTION
This pull request adds a bare-bones `webhook.handler` Lambda function that we can use to automatically clear cached entries & assets via [Contentful webhooks](https://www.contentful.com/developers/docs/concepts/webhooks/). While this could easily work for any space, it's currently only enabled for Phoenix.

~Blocked on DoSomething/infrastructure#168 (for support for multiple Lambdas under one "app").~