### PR TITLE
Fix issue with incorrect signups returned for posts.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -1,5 +1,6 @@
-import logger from 'heroku-logger';
+import { find } from 'lodash';
 import { stringify } from 'qs';
+import logger from 'heroku-logger';
 
 import config from '../../config';
 import {
@@ -259,8 +260,10 @@ export const getSignupsById = async (ids, options) => {
     options,
   );
   const json = await response.json();
+  const signups = transformCollection(json);
 
-  return transformCollection(json);
+  // Return signups in the same format requested. <https://git.io/fjLrM>
+  return ids.map(id => find(signups, ['id', id], null));
 };
 
 /**

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -149,6 +149,8 @@ const typeDefs = gql`
     updatedAt: DateTime
     "The time when this post was originally created."
     createdAt: DateTime
+    "Permalink to Admin view."
+    permalink: String
   }
 
   "A user's signup for a campaign."
@@ -306,6 +308,7 @@ const resolvers = {
     },
     reacted: post => post.reactions.reacted,
     reactions: post => post.reactions.total,
+    permalink: post => getPermalinkBySignupId(post.signupId),
   },
   Signup: {
     campaign: (signup, args, context) =>


### PR DESCRIPTION
This pull request fixes an issue where the `post.signup` resolver would sometimes return the wrong signup for a post. This is due to a mixup in the [expected behavior](https://git.io/fjLrM) for [DataLoader](https://github.com/graphql/dataloader), a utility we use for optimizing API requests, and the way I'd originally implemented this.

References [this Slack message](https://dosomething.slack.com/archives/CAPHYCR8V/p1554408980002400) & [Pivotal #165157990](https://www.pivotaltracker.com/story/show/165157990).