### PR TITLE
Fix typo'd field name on TextSubmissionBlock.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -176,7 +176,9 @@ const typeDefs = gql`
     "Optional label for the text field, helping describe or prompt the user regarding what to submit."
     textFieldLabel: String
     "Optional placeholder for the text field, providing an example of what a text submission should look like."
-    textFieldPlaceholderMessage: String
+    textFieldPlaceholderMessage: String  @deprecated(reason: "Use 'textFieldPlaceholder' instead.")
+    "Optional placeholder for the text field, providing an example of what a text submission should look like."
+    textFieldPlaceholder: String
     "Optional custom text to display on the submission button."
     buttonText: String
     "Optional custom title for the information block."
@@ -273,6 +275,9 @@ const resolvers = {
   },
   Block: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
+  },
+  TextSubmissionBlock: {
+    textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
   },
   ShareBlock: {
     affirmationBlock: linkResolver,


### PR DESCRIPTION
This addresses a bug that Jen just noticed with the text submission block on the Prom page – you can't set a custom placeholder because the field name in GraphQL (`textFieldPlaceholderMessage`) doesn't match up with [what we're looking for in the component in Phoenix](https://github.com/DoSomething/phoenix-next/blob/3ac4bb5936f5af675ab6605e7a5acdb2b71e9282/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js#L108).

This pull request adds a `textFieldPlaceholder` field, updates the typo'd one to read from it, and deprecates that field so we don't accidentally use it in the future.