### PR TITLE
Don't throw an exception if trying to drop a non-existant key.

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -77,7 +77,7 @@ export default class {
       // DynamoDB will throw an exception if you try to drop a key
       // that doesn't exist. We want to handle that gracefully.
       if (exception.errorMessage === 'Item does not exist') {
-        return Promise.resolve(null);
+        return null;
       }
 
       throw exception;

--- a/src/cache.js
+++ b/src/cache.js
@@ -65,14 +65,23 @@ export default class {
   /**
    * Remove the given key from the cache.
    * @param {String} key
-   * @param {*} value
    */
   async forget(key) {
     if (!this.policy.isReady()) {
       await this.client.start();
     }
 
-    return this.policy.drop(`${this.name}:${key}`);
+    try {
+      return this.policy.drop(`${this.name}:${key}`);
+    } catch (exception) {
+      // DynamoDB will throw an exception if you try to drop a key
+      // that doesn't exist. We want to handle that gracefully.
+      if (exception.errorMessage === 'Item does not exist') {
+        return Promise.resolve(null);
+      }
+
+      throw exception;
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request should clear up some (innocuous, but annoying) exceptions that we're seeing when our Contentful GraphQL webhooks try to clear cache for an entry that _isn't_ in the cache:

```
{"errorMessage":"Item does not exist","errorType":"Error","stackTrace":["Response.<anonymous> (/var/task/node_modules/catbox-dynamodb/lib/index.js:149:23)","Request.<anonymous> (/var/task/node_modules/aws-sdk/lib/request.js:364:18)","Request.callListeners (/var/task/node_modules/aws-sdk/lib/sequential_executor.js:106:20)","Request.emit (/var/task/node_modules/aws-sdk/lib/sequential_executor.js:78:10)","Request.emit (/var/task/node_modules/aws-sdk/lib/request.js:683:14)","Request.transition (/var/task/node_modules/aws-sdk/lib/request.js:22:10)","AcceptorStateMachine.runTo (/var/task/node_modules/aws-sdk/lib/state_machine.js:14:12)","/var/task/node_modules/aws-sdk/lib/state_machine.js:26:10","Request.<anonymous> (/var/task/node_modules/aws-sdk/lib/request.js:38:9)","Request.<anonymous> (/var/task/node_modules/aws-sdk/lib/request.js:685:12)"]} 
```

In #96, I found that the DynamoDB call would sometimes not be fired unless I [awaited on the result](https://github.com/DoSomething/graphql/blob/350b7c0ad2eb71a4f57d032cfab98c9cc61ce1c2/webhook.js#L45-L46) in the webhook, and so this function now immediately resolves `null` if the cache item doesn't exist (and otherwise re-throws the error). 