### PR TITLE
Affiliate Block and Affiliate by UTM Label Query

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -15,7 +15,7 @@ import { authorizedRequest } from './repositories/helpers';
 import {
   getPhoenixContentfulAssetById,
   getPhoenixContentfulEntryById,
-  getAffiliateByTitle,
+  getAffiliateByUtmLabel,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -39,8 +39,8 @@ export default (context, preview = false) => {
       actions: new DataLoader(ids =>
         Promise.all(ids.map(id => getActionById(id, options))),
       ),
-      affiliates: new DataLoader(titles =>
-        Promise.all(titles.map(title => getAffiliateByTitle(title, context))),
+      affiliates: new DataLoader(utmLabels =>
+        Promise.all(utmLabels.map(utmLabel => getAffiliateByUtmLabel(utmLabel, context))),
       ),
       assets: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulAssetById(id, context))),

--- a/src/loader.js
+++ b/src/loader.js
@@ -40,7 +40,7 @@ export default (context, preview = false) => {
         Promise.all(ids.map(id => getActionById(id, options))),
       ),
       affiliates: new DataLoader(titles =>
-        Promise.all(titles.map(title => getAffiliateByTitle(title, context)))
+        Promise.all(titles.map(title => getAffiliateByTitle(title, context))),
       ),
       assets: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulAssetById(id, context))),

--- a/src/loader.js
+++ b/src/loader.js
@@ -40,7 +40,9 @@ export default (context, preview = false) => {
         Promise.all(ids.map(id => getActionById(id, options))),
       ),
       affiliates: new DataLoader(utmLabels =>
-        Promise.all(utmLabels.map(utmLabel => getAffiliateByUtmLabel(utmLabel, context))),
+        Promise.all(
+          utmLabels.map(utmLabel => getAffiliateByUtmLabel(utmLabel, context)),
+        ),
       ),
       assets: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulAssetById(id, context))),

--- a/src/loader.js
+++ b/src/loader.js
@@ -15,6 +15,7 @@ import { authorizedRequest } from './repositories/helpers';
 import {
   getPhoenixContentfulAssetById,
   getPhoenixContentfulEntryById,
+  getAffiliateByTitle,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -37,6 +38,9 @@ export default (context, preview = false) => {
     set(context, 'loader', {
       actions: new DataLoader(ids =>
         Promise.all(ids.map(id => getActionById(id, options))),
+      ),
+      affiliates: new DataLoader(titles =>
+        Promise.all(titles.map(title => getAffiliateByTitle(title, context)))
       ),
       assets: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulAssetById(id, context))),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -113,17 +113,17 @@ const loadEntryByQuery = async (api, query) => {
 };
 
 /**
- * Search for Phoenix Contentful affiliate entries by text.
+ * Search for a Phoenix Contentful affiliate entry by utmLabel.
  *
  * @param {String} id
  * @return {Object}
  */
-export const getAffiliateByTitle = async (title, context) => {
+export const getAffiliateByUtmLabel = async (utmLabel, context) => {
   const { preview } = context;
 
   const query = {
     content_type: 'affiliates',
-    'fields.title': title,
+    'fields.utmLabel': utmLabel,
     limit: 1,
   };
 
@@ -139,7 +139,7 @@ export const getAffiliateByTitle = async (title, context) => {
   }
 
   // Otherwise, read from cache or Contentful's Content API:
-  return cache.remember(`Affiliate:${spaceId}:${title}`, async () =>
+  return cache.remember(`Affiliate:${spaceId}:${utmLabel}`, async () =>
     loadEntryByQuery(contentApi, query),
   );
 };

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -93,7 +93,10 @@ export const getPhoenixContentfulEntryById = async (id, context) => {
 export const getAffiliateByTitle = async (title, context) => {
   const { preview } = context;
 
-  logger.debug('Loading Phoenix Contentful affiliate entry', { title, preview });
+  logger.debug('Loading Phoenix Contentful affiliate entry', {
+    title,
+    preview,
+  });
 
   const loadEntry = async api => {
     try {
@@ -118,17 +121,18 @@ export const getAffiliateByTitle = async (title, context) => {
     }
 
     return null;
-  }
+  };
 
   // If we're previewing, use Contentful's Preview API and
   // don't bother trying to cache content on our end:
   if (preview) {
-    return loadEntry(previewApi)
+    return loadEntry(previewApi);
   }
 
   // Otherwise, read from cache or Contentful's Content API:
   return cache.remember(`Affiliate:${spaceId}:${title}`, async () =>
-    loadEntry(contentApi));
+    loadEntry(contentApi),
+  );
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -241,6 +241,8 @@ const typeDefs = gql`
     link: String
     "The affiliate's logo."
     logo: Asset
+    "The affiliate's UTM label."
+    utmLabel: String
     ${entryFields}
   }
 

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -249,7 +249,7 @@ const typeDefs = gql`
     block(id: String!, preview: Boolean = false): Block
     "Get an asset by ID."
     asset(id: String!, preview: Boolean = false): Asset
-    affiliate(title: String!, preview: Boolean = false): Block
+    affiliate(title: String!, preview: Boolean = false): AffiliateBlock
   }
 `;
 

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -143,7 +143,7 @@ const typeDefs = gql`
   }
 
   type ShareBlock implements Block {
-    "The internal-facing title for this text submission action."
+    "The internal-facing title for this share block."
     internalTitle: String!
     "The Action ID that 'share' posts will be submitted for."
     actionId: Int
@@ -193,7 +193,7 @@ const typeDefs = gql`
   }
 
   type PetitionSubmissionBlock implements Block {
-    "The internal-facing title for this photo submission action."
+    "The internal-facing title for this petition submission block."
     internalTitle: String!
     "The Action ID that posts will be submitted for."
     actionId: Int
@@ -219,9 +219,9 @@ const typeDefs = gql`
   }
 
   type VoterRegistrationBlock implements Block {
-    "The internal-facing title for this photo submission action."
+    "The internal-facing title for this voter registration block."
     internalTitle: String!
-    "The user-facing title for this share block."
+    "The user-facing title for this voter registration block."
     title: String
     "The voter registration block's text content."
     content: String

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -9,6 +9,7 @@ import Loader from '../../loader';
 import {
   createImageUrl,
   linkResolver,
+  getAffiliateByTitle,
 } from '../../repositories/contentful/phoenix';
 
 const entryFields = `
@@ -249,6 +250,7 @@ const typeDefs = gql`
     block(id: String!, preview: Boolean = false): Block
     "Get an asset by ID."
     asset(id: String!, preview: Boolean = false): Asset
+    affiliate(title: String!, preview: Boolean = false): Block
   }
 `;
 
@@ -284,6 +286,8 @@ const resolvers = {
       Loader(context, preview).blocks.load(id),
     asset: (_, { id, preview }, context) =>
       Loader(context, preview).assets.load(id),
+    affiliate: (_, { title, preview }, context) =>
+      Loader(context, preview).affiliates.load(title)
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -251,7 +251,7 @@ const typeDefs = gql`
     block(id: String!, preview: Boolean = false): Block
     "Get an asset by ID."
     asset(id: String!, preview: Boolean = false): Asset
-    affiliate(title: String!, preview: Boolean = false): AffiliateBlock
+    affiliate(utmLabel: String!, preview: Boolean = false): AffiliateBlock
   }
 `;
 
@@ -287,8 +287,8 @@ const resolvers = {
       Loader(context, preview).blocks.load(id),
     asset: (_, { id, preview }, context) =>
       Loader(context, preview).assets.load(id),
-    affiliate: (_, { title, preview }, context) =>
-      Loader(context, preview).affiliates.load(title),
+    affiliate: (_, { utmLabel, preview }, context) =>
+      Loader(context, preview).affiliates.load(utmLabel),
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -232,6 +232,18 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type AffiliateBlock implements Block {
+    "The internal-facing title for this affiliate block."
+    internalTitle: String!
+    "The title for this affiliate."
+    title: String!
+    "The link to the affiliate's website."
+    link: String
+    "The affiliate's logo."
+    logo: Asset
+    ${entryFields}
+  }
+
   type Query {
     "Get a block by ID."
     block(id: String!, preview: Boolean = false): Block
@@ -246,6 +258,7 @@ const typeDefs = gql`
  * @var {Object}
  */
 const contentTypeMappings = {
+  affiliates: 'AffiliateBlock',
   embed: 'EmbedBlock',
   imagesBlock: 'ImagesBlock',
   linkAction: 'LinkBlock',
@@ -296,6 +309,9 @@ const resolvers = {
   EmbedBlock: {
     previewImage: linkResolver,
   },
+  AffiliateBlock: {
+    logo: linkResolver,
+  }
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -311,7 +311,7 @@ const resolvers = {
   },
   AffiliateBlock: {
     logo: linkResolver,
-  }
+  },
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -9,7 +9,6 @@ import Loader from '../../loader';
 import {
   createImageUrl,
   linkResolver,
-  getAffiliateByTitle,
 } from '../../repositories/contentful/phoenix';
 
 const entryFields = `
@@ -287,7 +286,7 @@ const resolvers = {
     asset: (_, { id, preview }, context) =>
       Loader(context, preview).assets.load(id),
     affiliate: (_, { title, preview }, context) =>
-      Loader(context, preview).affiliates.load(title)
+      Loader(context, preview).affiliates.load(title),
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),

--- a/webhook.js
+++ b/webhook.js
@@ -50,12 +50,14 @@ exports.handler = async event => {
 
   // Clear AffiliateByTitle results for the specified title from the Contentful cache.
   if (contentType === 'affiliates') {
-    const title = body.fields.title;
+    const title = body.fields.title && body.fields.title['en-US'];
 
-    // Clear from DynamoDB (and await to make sure this completes).
-    await cache.forget(`Affiliate:${spaceId}:${title}`);
+    if (title) {
+      // Clear from DynamoDB (and await to make sure this completes).
+      await cache.forget(`Affiliate:${spaceId}:${title}`);
 
-    logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, title });
+      logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, title });
+    }
   }
 
   return response('Success.', 200);

--- a/webhook.js
+++ b/webhook.js
@@ -41,11 +41,22 @@ exports.handler = async event => {
   const id = body.sys.id;
   const type = body.sys.type;
   const spaceId = body.sys.space.sys.id;
+  const contentType = body.sys.contentType && body.sys.contentType.sys.id;
 
   // Clear from DynamoDB (and await to make sure this completes).
   await cache.forget(`${type}:${spaceId}:${id}`);
 
   logger.info('Cleared cache via Contentful webhook.', { spaceId, id });
+
+  // Clear AffiliateByTitle results for the specified title from the Contentful cache.
+  if (contentType === 'affiliates') {
+    const title = body.fields.title;
+
+    // Clear from DynamoDB (and await to make sure this completes).
+    await cache.forget(`Affiliate:${spaceId}:${title}`);
+
+    logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, title });
+  }
 
   return response('Success.', 200);
 };

--- a/webhook.js
+++ b/webhook.js
@@ -48,15 +48,15 @@ exports.handler = async event => {
 
   logger.info('Cleared cache via Contentful webhook.', { spaceId, id });
 
-  // Clear AffiliateByTitle results for the specified title from the Contentful cache.
+  // Clear AffiliateByTitle results for the specified utmLabel from the Contentful cache.
   if (contentType === 'affiliates') {
-    const title = body.fields.title && body.fields.title['en-US'];
+    const utmLabel = body.fields.utmLabel && body.fields.utmLabel['en-US'];
 
-    if (title) {
+    if (utmLabel) {
       // Clear from DynamoDB (and await to make sure this completes).
-      await cache.forget(`Affiliate:${spaceId}:${title}`);
+      await cache.forget(`Affiliate:${spaceId}:${utmLabel}`);
 
-      logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, title });
+      logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, utmLabel });
     }
   }
 


### PR DESCRIPTION
## What's This PR Do?

This PR adds a new Phoenix Contentful query to fetch an Affiliate entry by ~`title`~ `utmLabel` field search.

- new Affiliate block in Contentful Phoenix schema
- ~`getAffiliateByTitle`~ `getAffiliateByUtmLabel` method in the Phoenix Contentful Repository
- an `affiliates` DataLoader which resolves to the ~`getAffiliateByTitle`~ `getAffiliateByUtmLabel` method
- an `affiliate` Query in the Phoenix Contentful Repository

## Why Tho?
This query will serve to determine to display a Scholarship Card block over on Phoenix based on an affiliate referrer. 

## Source?
https://www.pivotaltracker.com/story/show/165599975