### PR TITLE
Fixes bug that broke askYesNo broadcast w/ only auto reply transitions

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -129,6 +129,11 @@ const linkResolvers = {
       fragment:
         'fragment ActionFragment on AskYesNoBroadcastTopic { actionId }',
       resolve(broadcastTopic, args, context, info) {
+        // AskYesNo broadcasts that reference an autoReplyTransition as the
+        // saidYes field will not have an actionId set
+        if (!broadcastTopic.actionId) {
+          return null;
+        }
         return info.mergeInfo.delegateToSchema(
           getGambitActionDelegateOptions(broadcastTopic, context, info),
         );


### PR DESCRIPTION
# What's this PR do
It adds a check to make sure that the `askYesNo` schema doesn't delegate the loading of the `action` field to the Rogue schema when the `actionId` field is empty.

# Relevant links
[Slack discussion](https://dosomething.slack.com/archives/C09ANFQLA/p1557342999092400)