### PR TITLE
Adds queries for badges

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -336,8 +336,7 @@ export const getSignupsCount = async (args, context) => {
       northstar_id: args.userId,
       source: args.source,
     },
-    limit: args.count,
-    pagination: 'cursor',
+    limit: args.limit,
   });
 
   logger.debug('Loading signups count from Rogue.', { args, queryString });
@@ -382,8 +381,7 @@ export const getPostsCount = async (args, context) => {
       type: args.type,
       tag: args.tags,
     },
-    limit: args.count,
-    pagination: 'cursor',
+    limit: args.limit,
   });
 
   logger.debug('Loading posts count from Rogue.', { args, queryString });

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -319,7 +319,7 @@ export const getSignupsByUserId = async (args, context) => {
 };
 
 /**
- * Fetch number of signups from Rogue by User ID.
+ * Fetch number of signups from Rogue based on the given filters.
  * NOTE: This will only find the number of signups up to the "limit" provided.
  * The limit defaults to 20.
  *
@@ -353,6 +353,47 @@ export const getSignupsCount = async (args, context) => {
 
   return result.length;
 };
+
+/**
+ * Fetch number of posts from Rogue based on the given filters.
+ * NOTE: This will only find the number of posts up to the "limit" provided.
+ * The limit defaults to 20.
+ *
+ * @param {String} action
+ * @param {String} actionIds
+ * @param {String} campaignId
+ * @param {Number} count
+ * @param {String} location
+ * @param {String} source
+ * @param {String} type
+ * @param {String} userId
+ * @param {String} tags
+ * @return Int
+ */
+export const getPostsCount = async (args, context) => {
+  const queryString = stringify({
+    filter: {
+      action: args.action,
+      action_id: args.actionIds ? args.actionIds.join(',') : undefined,
+      campaign_id: args.campaignId,
+      location: args.location,
+      northstar_id: args.userId,
+      source: args.source,
+      type: args.type,
+      tag: args.tags,
+    },
+    limit: args.count,
+    pagination: 'cursor',
+  });
+
+  logger.debug('Loading posts count from Rogue.', { args, queryString });
+
+  const response = await fetch(
+    `${ROGUE_URL}/api/v3/posts/?${queryString}`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
 
   const result = transformCollection(json);
 

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -306,6 +306,8 @@ export const getSignupsByUserId = async (args, context) => {
     pagination: 'cursor',
   });
 
+  logger.debug('Loading signups from Rogue.', { args, queryString });
+
   const response = await fetch(
     `${ROGUE_URL}/api/v3/signups/?${queryString}`,
     authorizedRequest(context),
@@ -314,4 +316,45 @@ export const getSignupsByUserId = async (args, context) => {
   const json = await response.json();
 
   return transformCollection(json);
+};
+
+/**
+ * Fetch number of signups from Rogue by User ID.
+ * NOTE: This will only find the number of signups up to the "limit" provided.
+ * The limit defaults to 20.
+ *
+ * @param {String} campaignId
+ * @param {Number} count
+ * @param {String} source
+ * @param {String} userId
+ * @return Int
+ */
+export const getSignupsCount = async (args, context) => {
+  const queryString = stringify({
+    filter: {
+      campaign_id: args.campaignId,
+      northstar_id: args.userId,
+      source: args.source,
+    },
+    limit: args.count,
+    pagination: 'cursor',
+  });
+
+  logger.debug('Loading signups count from Rogue.', { args, queryString });
+
+  const response = await fetch(
+    `${ROGUE_URL}/api/v3/signups/?${queryString}`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
+
+  const result = await transformCollection(json);
+
+  return result.length;
+};
+
+  const result = transformCollection(json);
+
+  return result.length;
 };

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -324,7 +324,7 @@ export const getSignupsByUserId = async (args, context) => {
  * The limit defaults to 20.
  *
  * @param {String} campaignId
- * @param {Number} count
+ * @param {Number} limit
  * @param {String} source
  * @param {String} userId
  * @return Int
@@ -361,7 +361,7 @@ export const getSignupsCount = async (args, context) => {
  * @param {String} action
  * @param {String} actionIds
  * @param {String} campaignId
- * @param {Number} count
+ * @param {Number} limit
  * @param {String} location
  * @param {String} source
  * @param {String} type

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -18,6 +18,7 @@ import {
   getSignupsByUserId,
   getSignupsCount,
   toggleReaction,
+  getPostsCount,
 } from '../repositories/rogue';
 
 /**
@@ -284,6 +285,27 @@ const typeDefs = gql`
       "The number of results per page."
       count: Int = 20
     ): Int
+    "Get post counts."
+    postsCount(
+      "The action name to load posts for."
+      action: String
+      "The action IDs to load posts for."
+      actionIds: [Int]
+      "# The campaign ID to load posts for."
+      campaignId: String
+      "The location to load posts for."
+      location: String
+      "# The post source to load posts for."
+      source: String
+      "# The type name to load posts for."
+      type: String
+      "# The user ID to load posts for."
+      userId: String
+      "A comma-separated list of tags to filter by."
+      tags: String
+      "# The number of results per page."
+      count: Int = 20
+    ): Int
   }
 
   type Mutation {
@@ -347,6 +369,7 @@ const resolvers = {
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),
     signupsCount: (_, args, context) => getSignupsCount(args, context),
+    postsCount: (_, args, context) => getPostsCount(args, context),
   },
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -282,8 +282,8 @@ const typeDefs = gql`
       source: String
       "The user ID to count signups for."
       userId: String
-      count: Int = 20
       "# The maximum count to report."
+      limit: Int = 20
     ): Int
     "Get post counts."
     postsCount(
@@ -303,8 +303,8 @@ const typeDefs = gql`
       userId: String
       "A comma-separated list of tags to filter by."
       tags: String
-      count: Int = 20
       "# The maximum count to report."
+      limit: Int = 20
     ): Int
   }
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -276,35 +276,35 @@ const typeDefs = gql`
     ): [Signup]
     "Find out how many signups a particular user has. Intended for use with badges."
     signupsCount(
-      "The Campaign ID load signups for."
+      "The Campaign ID count signups for."
       campaignId: String
-      "The signup source to load signups for."
+      "The signup source to count signups for."
       source: String
-      "The user ID to load signups for."
+      "The user ID to count signups for."
       userId: String
-      "The number of results per page."
       count: Int = 20
+      "# The maximum count to report."
     ): Int
     "Get post counts."
     postsCount(
-      "The action name to load posts for."
+      "The action name to count posts for."
       action: String
-      "The action IDs to load posts for."
+      "The action IDs to count posts for."
       actionIds: [Int]
-      "# The campaign ID to load posts for."
+      "# The campaign ID to count posts for."
       campaignId: String
-      "The location to load posts for."
+      "The location to count posts for."
       location: String
-      "# The post source to load posts for."
+      "# The post source to count posts for."
       source: String
-      "# The type name to load posts for."
+      "# The type name to count posts for."
       type: String
-      "# The user ID to load posts for."
+      "# The user ID to count posts for."
       userId: String
       "A comma-separated list of tags to filter by."
       tags: String
-      "# The number of results per page."
       count: Int = 20
+      "# The maximum count to report."
     ): Int
   }
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -16,6 +16,7 @@ import {
   getPostById,
   getSignups,
   getSignupsByUserId,
+  getSignupsCount,
   toggleReaction,
 } from '../repositories/rogue';
 
@@ -272,6 +273,17 @@ const typeDefs = gql`
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): [Signup]
+    "Find out how many signups a particular user has. Intended for use with badges."
+    signupsCount(
+      "The Campaign ID load signups for."
+      campaignId: String
+      "The signup source to load signups for."
+      source: String
+      "The user ID to load signups for."
+      userId: String
+      "The number of results per page."
+      count: Int = 20
+    ): Int
   }
 
   type Mutation {
@@ -334,6 +346,7 @@ const resolvers = {
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),
+    signupsCount: (_, args, context) => getSignupsCount(args, context),
   },
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),


### PR DESCRIPTION
## What's New

📡 Adds two very similar queries, one for posts and one for signups. This query is very similar to the `getPosts` and `getSignups` ones in that it allows filtering, but instead of returning signups or posts, it returns a count. The count by default is limited to 20, but that can be changed by passing the `count` parameter with the query (so if for a badge we know we only care if they have 3 posts, we can limit to 3).

At first I had a separate query for each count we wanted:
- count of signups by northstar id
- count of posts by northstar id
- count of posts by northstar id and tags
because it seems like that's how the other signups and posts queries work, but I realized that it could be condensed to one query for signups and one query for posts with filtering instead, so I went with that.

Here are examples of how to use these queries for badges, and also two bonus badge queries at the bottom that use existing queries:
```
# BADGES

# Staff Fave badge if result = 1, = 2, >=3 (one badge per level)
query PostCountsTagBadge{
  postsCount(userId: "5543de60469c64bf3d8b4616", tags: "good-submission")
}

# Campaign Signup x1 badge if result >= 1
query SignupCount{
  signupsCount(userId: "55a52809469c64d53d8ba74a")
}

#Completed Action x1, x2, x3 if result = 1, = 2, >=3
query PostCountsBadge{
  postsCount(userId: "54fa272b469c64d7068b456a")
}

# Signed up for the breakdown if result contains "news"
query SubscriptionTopicsBadge{
  user(id: "56e83a07469c64d8578b5ed4") {
    emailSubscriptionTopics
  }
}

# Registered to vote if result contains "confirmed" or "registration_complete"
query VoterRegBadge{
  posts(userId: "585403d6a0bfad76815b91cb", type: "voter-reg") {
    status
  }
}
```

## Card
[Pivotal Card](https://www.pivotaltracker.com/story/show/165839563)