### PR TITLE
Send proper Accept header on unauthorized requests.

### DIFF
--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -8,7 +8,7 @@ import { URL, URLSearchParams } from 'url';
  */
 export const authorizedRequest = context => {
   if (!context.authorization) {
-    return { Accept: 'application/json' };
+    return { headers: { Accept: 'application/json' } };
   }
 
   return {


### PR DESCRIPTION
This pull request fixes an issue where we wouldn't send the appropriate `Accept` header on unauthorized requests, which would cause 404s to error out when trying to parse the (default) HTML "not found" page:

![Screen Shot 2019-06-04 at 1 15 30 PM](https://user-images.githubusercontent.com/583202/58899800-cd28d880-86cb-11e9-8d5b-d8405a2f0b02.png)

And now, way more gracefully:

![Screen Shot 2019-06-04 at 1 20 52 PM](https://user-images.githubusercontent.com/583202/58899813-d31eb980-86cb-11e9-9f17-54c05c89768e.png)
