### PR TITLE
Ensure we only have one 'graphql' installed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4265,9 +4265,9 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "graphql": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
-      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
       "requires": {
         "iterall": "^1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dotenv": "^6.2.0",
     "esm": "^3.2.25",
     "express": "^4.17.1",
-    "graphql": "~14.0.0",
+    "graphql": "~14.2.1",
     "graphql-iso-date": "^3.5.0",
     "graphql-tools": "^4.0.3",
     "graphql-type-json": "^0.2.4",


### PR DESCRIPTION
This fixes an issue that was surfaced in our [post-deploy step](https://circleci.com/gh/DoSomething/graphql/594) where we had multiple versions of `graphql` installed (due to how npm resolves conflicting constraints) and that's no good!

> Error: Cannot use GraphQLSchema "[object GraphQLSchema]" from another module or realm.
>
> Duplicate "graphql" modules cannot be used at the same time since different versions may have different capabilities and behavior. The data from one version used in the function from another could produce confusing and spurious results.
