### PR TITLE
Remove separate (identical...) graphql subdependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -844,16 +844,6 @@
         "strip-ansi": "5.2.0",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "14.2.1",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
-          "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
-          "requires": {
-            "iterall": "^1.2.2"
-          }
-        }
       }
     },
     "apollo-cache-control": {
@@ -1037,14 +1027,6 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
           "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
-        },
-        "graphql": {
-          "version": "14.2.1",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
-          "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
-          "requires": {
-            "iterall": "^1.2.2"
-          }
         }
       }
     },


### PR DESCRIPTION
Once more! This pull request removes the two other `graphql` modules (same version) that were being installed before & causing the publish step to complain. Maybe an argument for swapping to Yarn for [selective dependency resolutions](https://yarnpkg.com/en/docs/selective-version-resolutions) here...