### PR TITLE
Expose badges property

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         }
       ],
       "space-unary-ops": "off",
-      "arrow-parens": "off"
+      "arrow-parens": "off",
+      "no-confusing-arrow": "off"
     }
   },
   "dependencies": {

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,3 +1,5 @@
+import { has } from 'lodash';
+
 /**
  * Transform a string constant into a GraphQL-style enum.
  *
@@ -25,5 +27,16 @@ export const listToEnums = list => {
 
   return list.map(stringToEnum);
 };
+
+/**
+ * See if a user has the given feature flag and what its value is.
+ *
+ * @param  {Object} user
+ * @param  {String} flagName
+
+ * @return {Boolean}
+ */
+export const hasFeatureFlag = (user, flagName) =>
+  has(user, `featureFlags.${flagName}`) ? user.featureFlags[flagName] : null;
 
 export default null;

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,5 +1,3 @@
-import { has } from 'lodash';
-
 /**
  * Transform a string constant into a GraphQL-style enum.
  *
@@ -27,16 +25,5 @@ export const listToEnums = list => {
 
   return list.map(stringToEnum);
 };
-
-/**
- * See if a user has the given feature flag and what its value is.
- *
- * @param  {Object} user
- * @param  {String} flagName
-
- * @return {Boolean}
- */
-export const hasFeatureFlag = (user, flagName) =>
-  has(user, `featureFlags.${flagName}`) ? user.featureFlags[flagName] : null;
 
 export default null;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -2,10 +2,9 @@ import { makeExecutableSchema } from 'graphql-tools';
 import { gql } from 'apollo-server';
 import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
-import { has } from 'lodash';
 
 import Loader from '../loader';
-import { stringToEnum, listToEnums } from './helpers';
+import { stringToEnum, listToEnums, hasFeatureFlag } from './helpers';
 import { updateEmailSubscriptionTopics } from '../repositories/northstar';
 
 /**
@@ -152,8 +151,7 @@ const resolvers = {
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
     emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
-    badges: user =>
-      has(user, 'featureFlags.badges') ? user.featureFlags.badges : null,
+    badges: user => hasFeatureFlag(user, 'badges'),
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -2,6 +2,7 @@ import { makeExecutableSchema } from 'graphql-tools';
 import { gql } from 'apollo-server';
 import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
+import { has } from 'lodash';
 
 import Loader from '../loader';
 import { stringToEnum, listToEnums } from './helpers';
@@ -120,6 +121,8 @@ const typeDefs = gql`
     votingPlanMethodOfTransport: String
     "What time of day user plans to get the polls to vote in upcoming election."
     votingPlanTimeOfDay: String
+    "Whether or not the user is opted-in to the badges experiment."
+    badges: Boolean
   }
 
   type Query {
@@ -149,6 +152,7 @@ const resolvers = {
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
     emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
+    badges: user => has(user, 'featureFlags.badges') ? user.featureFlags.badges : null,
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -153,8 +153,8 @@ const resolvers = {
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
     emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
     hasFeatureFlag: (user, { feature }) =>
-      has(user, `featureFlags.${feature}`) && user.featureFlags[feature] !== false
-    ,
+      has(user, `featureFlags.${feature}`) &&
+      user.featureFlags[feature] !== false,
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -152,7 +152,8 @@ const resolvers = {
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
     emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
-    badges: user => has(user, 'featureFlags.badges') ? user.featureFlags.badges : null,
+    badges: user =>
+      has(user, 'featureFlags.badges') ? user.featureFlags.badges : null,
   },
   Query: {
     user: (_, args, context) => Loader(context).users.load(args.id),


### PR DESCRIPTION
### What's New
You can now do a query like this:
```
query GetUserFalse{
  user(id: "5cacef40fdce271a65654f12") {
    firstName
    lastName
    hasFeatureFlag(feature: "badges")
  }
}
```
and get a result like this:
```
"data": {
    "user": {
      "firstName": "Katie",
      "lastName": null,
      "hasFeatureFlag": true
    }
 },
```
where the value of `badges` is either `true` or `false`. `true` represent the folks opted in to the feature. `false` represent the folks not in the feature, or not assigned a value for the feature. In Phoenix, I'll be adding this as a field to the user query for the profile, and surfacing the badge work only if that value is `true`. 

I also turned off the `no-confusing-arrow` linting rule because it was the opposite of helpful! Previously discussed in [this thread](https://dosomething.slack.com/archives/CAPHYCR8V/p1551476766013600).