### PR TITLE
Add Campaign Website Type & Campaign ID query

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -16,6 +16,7 @@ import {
   getPhoenixContentfulAssetById,
   getPhoenixContentfulEntryById,
   getAffiliateByUtmLabel,
+  getCampaignWebsiteByCampaignId,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -58,6 +59,9 @@ export default (context, preview = false) => {
       ),
       campaignWebsites: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
+      ),
+      campaignWebsiteByCampaignIds: new DataLoader(campaignIds =>
+        Promise.all(campaignIds.map(campaignId => getCampaignWebsiteByCampaignId(campaignId, context))),
       ),
       conversations: new DataLoader(ids =>
         Promise.all(ids.map(id => getConversationById(id, options))),

--- a/src/loader.js
+++ b/src/loader.js
@@ -61,7 +61,11 @@ export default (context, preview = false) => {
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
       ),
       campaignWebsiteByCampaignIds: new DataLoader(campaignIds =>
-        Promise.all(campaignIds.map(campaignId => getCampaignWebsiteByCampaignId(campaignId, context))),
+        Promise.all(
+          campaignIds.map(campaignId =>
+            getCampaignWebsiteByCampaignId(campaignId, context),
+          ),
+        ),
       ),
       conversations: new DataLoader(ids =>
         Promise.all(ids.map(id => getConversationById(id, options))),

--- a/src/loader.js
+++ b/src/loader.js
@@ -56,6 +56,9 @@ export default (context, preview = false) => {
       campaigns: new DataLoader(ids =>
         Promise.all(ids.map(id => getCampaignById(id, options))),
       ),
+      campaignWebsites: new DataLoader(ids =>
+        Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
+      ),
       conversations: new DataLoader(ids =>
         Promise.all(ids.map(id => getConversationById(id, options))),
       ),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -113,6 +113,40 @@ const loadEntryByQuery = async (api, query) => {
 };
 
 /**
+ * Search for a Phoenix Contentful Campaign entry by campaignId.
+ *
+ * @param {String} id
+ * @return {Object}
+ */
+export const getCampaignWebsiteByCampaignId = async (campaignId, context) => {
+  const { preview } = context;
+
+  const query = {
+    content_type: 'campaign',
+    // The Contentful field ID is (unfortunately) legacyCampaignId. (An #Ashes remnant 😿).
+    'fields.legacyCampaignId': campaignId,
+    order: '-sys.updatedAt',
+    limit: 1,
+  };
+
+  logger.debug('Loading Phoenix Contentful entry', {
+    query,
+    preview,
+  });
+
+  // If we're previewing, use Contentful's Preview API and
+  // don't bother trying to cache content on our end:
+  if (preview) {
+    return loadEntryByQuery(previewApi, query);
+  }
+
+  // Otherwise, read from cache or Contentful's Content API:
+  return cache.remember(`CampaignWebste:${spaceId}:${campaignId}`, async () =>
+    loadEntryByQuery(contentApi, query),
+  );
+}
+
+/**
  * Search for a Phoenix Contentful affiliate entry by utmLabel.
  *
  * @param {String} id

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -144,7 +144,7 @@ export const getCampaignWebsiteByCampaignId = async (campaignId, context) => {
   return cache.remember(`CampaignWebste:${spaceId}:${campaignId}`, async () =>
     loadEntryByQuery(contentApi, query),
   );
-}
+};
 
 /**
  * Search for a Phoenix Contentful affiliate entry by utmLabel.

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -263,6 +263,7 @@ const typeDefs = gql`
     asset(id: String!, preview: Boolean = false): Asset
     affiliate(utmLabel: String!, preview: Boolean = false): AffiliateBlock
     campaignWebsite(id: String!, preview: Boolean = false): CampaignWebsite
+    campaignWebsiteByCampaignId(campaignId: String!, preview: Boolean = false): CampaignWebsite
   }
 `;
 
@@ -303,6 +304,8 @@ const resolvers = {
       Loader(context, preview).affiliates.load(utmLabel),
     campaignWebsite: (_, { id, preview }, context) =>
       Loader(context, preview).campaignWebsites.load(id),
+    campaignWebsiteByCampaignId: (_, { campaignId, preview }, context) =>
+      Loader(context, preview).campaignWebsiteByCampaignIds.load(campaignId),
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -60,6 +60,16 @@ const typeDefs = gql`
     url(w: Int, h: Int, fit: ResizeOption): AbsoluteUrl,
   }
 
+  type CampaignWebsite {
+    "The internal-facing title for this campaign."
+    internalTitle: String!
+    "The user-facing title for this campaign."
+    title: String!
+    "The slug for this campaign."
+    slug: String!
+    ${entryFields}
+  }
+
   type ImagesBlock implements Block {
     "The images to be included in this block."
     images: [Asset]
@@ -252,6 +262,7 @@ const typeDefs = gql`
     "Get an asset by ID."
     asset(id: String!, preview: Boolean = false): Asset
     affiliate(utmLabel: String!, preview: Boolean = false): AffiliateBlock
+    campaignWebsite(id: String!, preview: Boolean = false): CampaignWebsite
   }
 `;
 
@@ -262,6 +273,7 @@ const typeDefs = gql`
  */
 const contentTypeMappings = {
   affiliates: 'AffiliateBlock',
+  campaignWebsite: 'CampaignWebsite',
   embed: 'EmbedBlock',
   imagesBlock: 'ImagesBlock',
   linkAction: 'LinkBlock',
@@ -289,6 +301,8 @@ const resolvers = {
       Loader(context, preview).assets.load(id),
     affiliate: (_, { utmLabel, preview }, context) =>
       Loader(context, preview).affiliates.load(utmLabel),
+    campaignWebsite: (_, { id, preview }, context) =>
+      Loader(context, preview).campaignWebsites.load(id),
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),

--- a/webhook.js
+++ b/webhook.js
@@ -48,7 +48,7 @@ exports.handler = async event => {
 
   logger.info('Cleared cache via Contentful webhook.', { spaceId, id });
 
-  // Clear AffiliateByTitle results for the specified utmLabel from the Contentful cache.
+  // Clear AffiliateByUtmLabel results for the specified utmLabel from the Contentful cache.
   if (contentType === 'affiliates') {
     const utmLabel = body.fields.utmLabel && body.fields.utmLabel['en-US'];
 
@@ -57,6 +57,18 @@ exports.handler = async event => {
       await cache.forget(`Affiliate:${spaceId}:${utmLabel}`);
 
       logger.info('Cleared affiliate cache via Contentful webhook.', { spaceId, utmLabel });
+    }
+  }
+
+  // Clear CampaignWebsiteByCampaignId results for the specified campaignId from the Contentful cache.
+  if (contentType === 'campaign') {
+    const campaignId = body.fields.legacyCampaignId && body.fields.legacyCampaignId['en-US'];
+
+    if (campaignId) {
+      // Clear from DynamoDB (and await to make sure this completes).
+      await cache.forget(`CampaignWebsite:${spaceId}:${campaignId}`);
+
+      logger.info('Cleared campaignWebsite cache via Contentful webhook.', { spaceId, campaignId });
     }
   }
 

--- a/webhook.js
+++ b/webhook.js
@@ -66,7 +66,7 @@ exports.handler = async event => {
         // Clear from DynamoDB (and await to make sure this completes).
         await cache.forget(`${contentType}:${spaceId}:${fieldValue}`);
 
-        logger.info(`Cleared ${contentType} cache via Contentful webhook`);
+        logger.info(`Cleared ${contentType} cache via Contentful webhook`, { spaceId, id, [cacheKey]: fieldValue });
       }
     };
   }

--- a/webhook.js
+++ b/webhook.js
@@ -66,7 +66,11 @@ exports.handler = async event => {
         // Clear from DynamoDB (and await to make sure this completes).
         await cache.forget(`${contentType}:${spaceId}:${fieldValue}`);
 
-        logger.info(`Cleared ${contentType} cache via Contentful webhook`, { spaceId, id, [cacheKey]: fieldValue });
+        logger.info(`Cleared ${contentType} cache via Contentful webhook`, {
+          spaceId,
+          id,
+          [cacheKey]: fieldValue,
+        });
       }
     };
   }


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `CampaignWebsite` Type to the contentful/phoenix schema along with a Data Loader to allow querying Contentful Campaigns from the Phoenix Contentful space.

It also adds a `getCampaignWebsiteByCampaignId` query to allow querying Phoenix Contentful Campaigns by the `legacyCampaignId` field.

### Any background context you want to provide?
This will allow Rogue to use the Campaign ID associated with Posts/Signups to pass along website specific information to our email service for more customized triggered emails.

And of course, it also opens the floor for other services to start grabbing Contentful Campaigns via Graphql

### What are the relevant tickets/cards?

Refs [Pivotal ID #166360235](https://www.pivotaltracker.com/story/show/166360235)
