### PR TITLE
Safely grab the field value for secondary cache keys

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -60,7 +60,8 @@ exports.handler = async event => {
 
     for (let i = 0; i < cacheKeys.length; i++) {
       const cacheKey = cacheKeys[i];
-      const fieldValue = body.fields[cacheKey] && body.fields[cacheKey]['en-US'];
+        const fieldValue =
+          body.fields && body.fields['cacheKey'] && body.fields['cacheKey']['en-US'];
 
       if (fieldValue) {
         // Clear from DynamoDB (and await to make sure this completes).

--- a/webhook.js
+++ b/webhook.js
@@ -60,8 +60,8 @@ exports.handler = async event => {
 
     for (let i = 0; i < cacheKeys.length; i++) {
       const cacheKey = cacheKeys[i];
-        const fieldValue =
-          body.fields && body.fields['cacheKey'] && body.fields['cacheKey']['en-US'];
+      const fieldValue =
+        body.fields && body.fields['cacheKey'] && body.fields['cacheKey']['en-US'];
 
       if (fieldValue) {
         // Clear from DynamoDB (and await to make sure this completes).


### PR DESCRIPTION
### What's this all about?
This PR contains A quick patch to ensure we're not erroneously calling a field on an `undefined` object when attempting to find a cache key value from the Contentful webhook payload.

(When an entry is deleted, the payload will not pass through a `fields` property).

### Any context?
https://dosomething.slack.com/archives/CAPHYCR8V/p1560805236002400