### PR TITLE
Add tags filter to posts query.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -84,6 +84,7 @@ export const getCampaigns = async (args, context) => {
  * @param {String} location
  * @param {Number} page
  * @param {String} source
+ * @param {String} tags
  * @param {String} type
  * @param {String} userId
  * @return {Array}
@@ -97,6 +98,7 @@ export const getPosts = async (args, context) => {
       location: args.location,
       northstar_id: args.userId,
       source: args.source,
+      tag: args.tags ? args.tags.join(',') : undefined,
       type: args.type,
     },
     page: args.page,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -219,6 +219,8 @@ const typeDefs = gql`
       location: String
       "# The post source to load posts for."
       source: String
+      "# The tags to load posts for."
+      tags: [String]
       "# The type name to load posts for."
       type: String
       "# The user ID to load posts for."


### PR DESCRIPTION
This PR adds a `tags` argument to the `posts` query, which will allow us to query posts by one or more tags (e.g. `good-submission`, `good-for-sponsor`, etc) when rendering galleries.