### PR TITLE
Fix competing 'graphql' versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.7.tgz",
-      "integrity": "sha512-+ertvzAwzkYmuUtT8zH3Zi6jPdyxZwOgnYaZHY7iLnMVJDhQKWlkyjLMF8wyzlPiEdDImVUMm5lOIBZo7LkGlg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz",
+      "integrity": "sha512-7wEO+S+zgz/wVe3ilFQqICufRBYYDSNUkd1V03JWvXuSydbYq2SM5EgvWmFF+04iadt+aQ0XCCsRzCzRPQODfQ==",
       "requires": {
         "apollo-env": "0.5.1"
       }
@@ -94,40 +94,14 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-          "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.5.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-          "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
+      "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -211,19 +185,6 @@
         "@babel/template": "^7.4.4",
         "@babel/traverse": "^7.5.0",
         "@babel/types": "^7.5.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-          "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/highlight": {
@@ -299,38 +260,12 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-          "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.5.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-          "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
+      "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -384,9 +319,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.14",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.14.tgz",
-      "integrity": "sha512-R9gat0yUjamDVd4trvFgjlx2XYuMz1nM0uEBFP6nR1zOQAwJ3E1zqYbsVlCMWiUDGjU1hYmudmK7IjAxDUoqDw==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.16.tgz",
+      "integrity": "sha512-bzqNz9/EblkohokXbico/14r05oRe8aa06S3MLEo4GlmyOce2abIOx1oZfUDl8ekQuKO+Ycw9Jco+hN2aL423A==",
       "requires": {
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.7.3",
@@ -735,9 +670,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
-      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ=="
+      "version": "12.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.6.tgz",
+      "integrity": "sha512-SMgj3x28MkJyHdWaMv/g/ca3LYDi5gR7O8mX0VKazvFOnmlDXctSEdd/8jfSqozjKFK1R9If1QZWkafX7yQTpA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -883,12 +818,12 @@
       }
     },
     "apollo": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.15.0.tgz",
-      "integrity": "sha512-EQDrJ4aEcZ96AO5BXDaS4v6GwO8T1vKlPg3GMM4WUo5gZKPKsz1QqwJb4tE2uoksADzdvO+Jd91c73eOxBWTCA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.16.0.tgz",
+      "integrity": "sha512-yStTQ/YDaDk/IY3YeRhhy9sfHdqQxRmVoV5zinLKUeCRxxarxl7xOTz0jcyic1YKF36TObn3QMPPJ8CRg5XWKw==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.7",
-        "@oclif/command": "1.5.14",
+        "@apollographql/apollo-tools": "0.4.0",
+        "@oclif/command": "1.5.16",
         "@oclif/config": "1.13.0",
         "@oclif/errors": "1.2.2",
         "@oclif/plugin-autocomplete": "0.1.1",
@@ -896,14 +831,14 @@
         "@oclif/plugin-not-found": "1.2.2",
         "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.34.8",
-        "apollo-codegen-flow": "0.33.18",
-        "apollo-codegen-scala": "0.34.18",
-        "apollo-codegen-swift": "0.33.18",
-        "apollo-codegen-typescript": "0.34.8",
+        "apollo-codegen-core": "0.34.9",
+        "apollo-codegen-flow": "0.33.19",
+        "apollo-codegen-scala": "0.34.19",
+        "apollo-codegen-swift": "0.34.0",
+        "apollo-codegen-typescript": "0.34.9",
         "apollo-env": "0.5.1",
         "apollo-graphql": "0.3.3",
-        "apollo-language-server": "1.12.0",
+        "apollo-language-server": "1.13.0",
         "chalk": "2.4.2",
         "env-ci": "3.2.2",
         "gaze": "1.1.3",
@@ -920,50 +855,40 @@
         "strip-ansi": "5.2.0",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "14.4.2",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-          "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-          "requires": {
-            "iterall": "^1.2.2"
-          }
-        }
       }
     },
     "apollo-cache-control": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.7.5.tgz",
-      "integrity": "sha512-zCPwHjbo/VlmXl0sclZfBq/MlVVeGUAg02Q259OIXSgHBvn9BbExyz+EkO/DJvZfGMquxqS1X1BFO3VKuLUTdw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.0.tgz",
+      "integrity": "sha512-BBnfUmSWRws5dRSDD+R56RLJCE9v6xQuob+i/1Ju9EX4LZszU5JKVmxEvnkJ1bk/BkihjoQXTnP6fJCnt6fCmA==",
       "requires": {
         "apollo-server-env": "2.4.0",
-        "graphql-extensions": "0.7.7"
+        "graphql-extensions": "0.8.0"
       }
     },
     "apollo-codegen-core": {
-      "version": "0.34.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.34.8.tgz",
-      "integrity": "sha512-n767UBbmr6ZaIfxEmLfOOklqxD80m3zrGT1pnXuHYFugTmIpIPNRQlbHRxk38naBBWQeXBkSjnTRg7jq/KNaBg==",
+      "version": "0.34.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.34.9.tgz",
+      "integrity": "sha512-70UiWIW3WmmUoixUV4W5Um4DJGQetpeL6ZwALFDrIHpjZwlMsOhQVDRe1gS7pLtuxxdvjhOcP/kiGbrSvQaPrg==",
       "requires": {
-        "@babel/generator": "7.4.4",
+        "@babel/generator": "7.5.0",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.4.4",
+        "@babel/types": "7.5.0",
         "apollo-env": "0.5.1",
-        "apollo-language-server": "1.12.0",
+        "apollo-language-server": "1.13.0",
         "ast-types": "^0.13.0",
         "common-tags": "^1.5.1",
         "recast": "^0.18.0"
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.33.18",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.18.tgz",
-      "integrity": "sha512-afRTZCeDvBNN3OiiEY0OnT4jHE98IVyjVtT+3b4siCZF8auYZxhmdkK1D6KgX3dHAJ3c0r0td6o9q09/+HNESA==",
+      "version": "0.33.19",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.19.tgz",
+      "integrity": "sha512-OaWoAsvJG69jp2h+Uu6DXTMlsk5FMCqpJkLQSxu7gAFxF8/PQF0waL9YB6EvVRFCGdJDr70KgFmLjGjfubuCkQ==",
       "requires": {
-        "@babel/generator": "7.4.4",
-        "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.34.8",
+        "@babel/generator": "7.5.0",
+        "@babel/types": "7.5.0",
+        "apollo-codegen-core": "0.34.9",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -971,11 +896,11 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.34.18",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.18.tgz",
-      "integrity": "sha512-FtaO60R4BJQN6YFMnhbSIDXfmCyQ5oDUJ6sF/rA07vrjLMj54SsA05XK/1+b5VO0OsQKjI2UiA78VbAygxD2dQ==",
+      "version": "0.34.19",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.19.tgz",
+      "integrity": "sha512-SgkJ5ZyEOnt3svXY7q1yp2Fc42Qw83drtmc+NcDW0gcVSAB+zILosg43q29AUWw9MU2fiNfl4mRCaOw80AiVGQ==",
       "requires": {
-        "apollo-codegen-core": "0.34.8",
+        "apollo-codegen-core": "0.34.9",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -983,11 +908,11 @@
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.33.18",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.18.tgz",
-      "integrity": "sha512-Inx0i+aN+z/o/F5WP9G5TjQFfl8NRvrlMzbz1HJi0ADx9YsqSbaoLHwPLkuBOgIHaWnPIoCGf5GMyeqYDellww==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.34.0.tgz",
+      "integrity": "sha512-HZlnZ/2tqjSudhxQxkDs49jjiXmgjrMV3zf8PCCdeTxzGhp9hbTD5f/BLF8rL7c3f4UjG3CZr9KOqTx1i1dYww==",
       "requires": {
-        "apollo-codegen-core": "0.34.8",
+        "apollo-codegen-core": "0.34.9",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -995,13 +920,13 @@
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.34.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.34.8.tgz",
-      "integrity": "sha512-PqNwHQ1vPGUqf7NoWYXg2Fwq3ZgqTCfkb3pjJVLX2+DyhqCDxHegk7BbfJ7f71JE3N9MQplOBWnANTY/imx4OQ==",
+      "version": "0.34.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.34.9.tgz",
+      "integrity": "sha512-XgvBjPObM+Zt2mUO1xfw+Erp50CL5ppLAv3du/mncZYo8soaN1BZCEBXgPUmW4SsAK4hh+kfBZ96eszr8mUXeg==",
       "requires": {
-        "@babel/generator": "7.4.4",
-        "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.34.8",
+        "@babel/generator": "7.5.0",
+        "@babel/types": "7.5.0",
+        "apollo-codegen-core": "0.34.9",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1018,22 +943,22 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.3.6.tgz",
-      "integrity": "sha512-oCoFAUBGveg1i1Sao/2gNsf1kirJBT6vw6Zan9BCNUkyh68ewDts+xRg32VnD9lDhaHpXVJ3tVtuaV44HmdSEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.0.tgz",
+      "integrity": "sha512-NMiO3h1cuEBt6QZNGHxivwuyZQnoU/2MMx0gUA8Gyy1ERBhK6P235qoMnvoi34rLmqJuyGPX6tXcab8MpMIzYQ==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "0.3.1",
+        "apollo-engine-reporting-protobuf": "0.4.0",
         "apollo-graphql": "^0.3.3",
-        "apollo-server-core": "2.6.9",
         "apollo-server-env": "2.4.0",
+        "apollo-server-types": "0.2.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "0.7.7"
+        "graphql-extensions": "0.8.0"
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.3.1.tgz",
-      "integrity": "sha512-Ui3nPG6BSZF8BEqxFs6EkX6mj2OnFLMejxEHSOdM82bakyeouCGd7J0fiy8AD6liJoIyc4X7XfH4ZGGMvMh11A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.0.tgz",
+      "integrity": "sha512-cXHZSienkis8v4RhqB3YG3DkaksqLpcxApRLTpRMs7IXNozgV7CUPYGFyFBEra1ZFgUyHXx4G9MpelV+n2cCfA==",
       "requires": {
         "protobufjs": "^6.8.6"
       }
@@ -1058,11 +983,11 @@
       }
     },
     "apollo-language-server": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.12.0.tgz",
-      "integrity": "sha512-tCzUob9oaZNlahYJu3SfAFdaTaBDJHJkZlMaIc53jNT7ibIVh0ZziqMZexf/SNLD1NRHt4IRCD5eVsXcq9PaAg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.13.0.tgz",
+      "integrity": "sha512-cw67oI8UYokGuNY+uvrE23I7YkIdce/EPX8vbLJrXtQXgdD6zFo66AckOuiNxXexayijLH8iLjhcfYndL7Vtyw==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.7",
+        "@apollographql/apollo-tools": "0.4.0",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
         "apollo-datasource": "^0.5.0",
@@ -1091,14 +1016,6 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
           "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
-        },
-        "graphql": {
-          "version": "14.4.2",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-          "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-          "requires": {
-            "iterall": "^1.2.2"
-          }
         }
       }
     },
@@ -1153,12 +1070,12 @@
       }
     },
     "apollo-server": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.6.9.tgz",
-      "integrity": "sha512-thZxUHVM1CLl3503gMCVirxN9J/33s5C1R+hHMEfLaUSoDlXSMA81Y9LCOi9+6d0C9l5DwiZCFXeZI/fKic2RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.7.0.tgz",
+      "integrity": "sha512-UKYROQqcwSgIjUEjaxAllRJQFTa3flPY+fV5Q0Kz2e3XE5QomEkuNBmO54IefIOr8LllhRU9246WmMHRuwun+w==",
       "requires": {
-        "apollo-server-core": "2.6.9",
-        "apollo-server-express": "2.6.9",
+        "apollo-server-core": "2.7.0",
+        "apollo-server-express": "2.7.0",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -1173,23 +1090,25 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.6.9.tgz",
-      "integrity": "sha512-r2/Kjm1UmxoTViUt5EcExWXkWl0riXsuGyS1q5LpHKKnA+6b+t4LQKECkRU4EWNpuuzJQn7aF7MmMdvURxoEig==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.7.0.tgz",
+      "integrity": "sha512-CXjXAkgcMBCJZpsZgfAY5W7f5thdxUhn75UgzeH28RTUZ2aKi/LjoCixPWRSF1lU4vuEWneAnM8Vg/KCD+29lQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.3.6",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "0.7.5",
-        "apollo-datasource": "0.5.0",
-        "apollo-engine-reporting": "1.3.6",
-        "apollo-server-caching": "0.4.0",
+        "apollo-cache-control": "0.8.0",
+        "apollo-datasource": "0.6.0",
+        "apollo-engine-reporting": "1.4.0",
+        "apollo-engine-reporting-protobuf": "0.4.0",
+        "apollo-server-caching": "0.5.0",
         "apollo-server-env": "2.4.0",
         "apollo-server-errors": "2.3.1",
-        "apollo-server-plugin-base": "0.5.8",
-        "apollo-tracing": "0.7.4",
+        "apollo-server-plugin-base": "0.6.0",
+        "apollo-server-types": "0.2.0",
+        "apollo-tracing": "0.8.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "0.7.7",
+        "graphql-extensions": "0.8.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
@@ -1197,6 +1116,33 @@
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "@apollographql/apollo-tools": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.7.tgz",
+          "integrity": "sha512-+ertvzAwzkYmuUtT8zH3Zi6jPdyxZwOgnYaZHY7iLnMVJDhQKWlkyjLMF8wyzlPiEdDImVUMm5lOIBZo7LkGlg==",
+          "requires": {
+            "apollo-env": "0.5.1"
+          }
+        },
+        "apollo-datasource": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.0.tgz",
+          "integrity": "sha512-DOzzYWEOReYRu2vWPKEulqlTb9Xjg67sjVCzve5MXa7GUXjfr8IKioljvfoBMlqm/PpbJVk2ci4n5NIFqoYsrQ==",
+          "requires": {
+            "apollo-server-caching": "0.5.0",
+            "apollo-server-env": "2.4.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.0.tgz",
+          "integrity": "sha512-l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==",
+          "requires": {
+            "lru-cache": "^5.0.0"
+          }
+        }
       }
     },
     "apollo-server-env": {
@@ -1214,9 +1160,9 @@
       "integrity": "sha512-errZvnh0vUQChecT7M4A/h94dnBSRL213dNxpM5ueMypaLYgnp4hiCTWIEaooo9E4yMGd1qA6WaNbLDG2+bjcg=="
     },
     "apollo-server-express": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.6.9.tgz",
-      "integrity": "sha512-iTkdIdX7m9EAlmL/ZPkKR+x/xuFk1HYZWuJIJG57hHUhcOxj50u7F1E5+5fDwl5RFIdepQ61azF31hhNZuNi4g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.7.0.tgz",
+      "integrity": "sha512-TIOaLyuxD8xIECXjbPfS9HUWgHCKsG3rR4WuTpTreVEB08EsGeg+VcNGn0hmUnch18fPXTciBHWCv/fFV/YhMg==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
@@ -1224,7 +1170,8 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.17.0",
         "accepts": "^1.3.5",
-        "apollo-server-core": "2.6.9",
+        "apollo-server-core": "2.7.0",
+        "apollo-server-types": "0.2.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^1.0.0",
@@ -1233,28 +1180,52 @@
       }
     },
     "apollo-server-lambda": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/apollo-server-lambda/-/apollo-server-lambda-2.6.9.tgz",
-      "integrity": "sha512-mQ9wj09uwzeLbXDo3rdonozMfAlZ3Pwv0Fv0RfhPmQpigaOjYluUfZrKWrq4E9qmKVIgRbbUd5T65IlubkDDCw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-lambda/-/apollo-server-lambda-2.7.0.tgz",
+      "integrity": "sha512-h/HzcEBbyUn7V4yYm3+GE3r+jWAHPcVw5AI1AQGWpP8+HHx8ggMmmJ3rf+EuMK4AT2uiBii4mWyCQBpbjGNiHw==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
-        "apollo-server-core": "2.6.9",
+        "apollo-server-core": "2.7.0",
         "apollo-server-env": "2.4.0",
+        "apollo-server-types": "0.2.0",
         "graphql-tools": "^4.0.0"
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.8.tgz",
-      "integrity": "sha512-ICbaXr0ycQZL5llbtZhg8zyHbxuZ4khdAJsJgiZaUXXP6+F47XfDQ5uwnl/4Sq9fvkpwS0ctvfZ1D+Ks4NvUzA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.0.tgz",
+      "integrity": "sha512-BjfyWpHyKwHOe819gk3wEFwbnVp9Xvos03lkkYTTcXS/8G7xO78aUcE65mmyAC56/ZQ0aodNFkFrhwNtWBQWUQ==",
+      "requires": {
+        "apollo-server-types": "0.2.0"
+      }
+    },
+    "apollo-server-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.0.tgz",
+      "integrity": "sha512-5dgiyXsM90vnfmdXO1ixHvsLn0d9NP4tWufmr3ZmjKv00r4JAQNUaUdgOSGbRIKoHELQGwxUuTySTZ/tYfGaNQ==",
+      "requires": {
+        "apollo-engine-reporting-protobuf": "0.4.0",
+        "apollo-server-caching": "0.5.0",
+        "apollo-server-env": "2.4.0"
+      },
+      "dependencies": {
+        "apollo-server-caching": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.0.tgz",
+          "integrity": "sha512-l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==",
+          "requires": {
+            "lru-cache": "^5.0.0"
+          }
+        }
+      }
     },
     "apollo-tracing": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.7.4.tgz",
-      "integrity": "sha512-vA0FJCBkFpwdWyVF5UtCqN+enShejyiqSGqq8NxXHU1+GEYTngWa56x9OGsyhX+z4aoDIa3HPKPnP3pjzA0qpg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.0.tgz",
+      "integrity": "sha512-cNOtOlyZ56iJRsCjnxjM1V0SnQ2ZZttuyoeOejdat6llPfk5bfYTVOKMjdbSfDvU33LS9g9sqNJCT0MwrEPFKQ==",
       "requires": {
         "apollo-server-env": "2.4.0",
-        "graphql-extensions": "0.7.7"
+        "graphql-extensions": "0.8.0"
       }
     },
     "apollo-utilities": {
@@ -2289,9 +2260,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "contentful": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.8.1.tgz",
-      "integrity": "sha512-HHQ8kxcJ4YITiBUTChY/bxAZVxSGf9wv4aBg9XmlFmebbKijF1hAY5h4vlcE0EgrxG8nHnSOK1RlsUjaDym39w==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.8.2.tgz",
+      "integrity": "sha512-8aaCOxk2FJv5mDZlPh9s6BKj6rkjqGghtVuKXwx/sEYRQZVBsvvQgq+pMnN5XvTE2EHPEfu6C9d5J5cvbWlOjg==",
       "requires": {
         "axios": "^0.19.0",
         "contentful-resolve-response": "^1.1.4",
@@ -4316,20 +4287,31 @@
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
     "graphql": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
-      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
+      "version": "14.4.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
+      "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
       "requires": {
         "iterall": "^1.2.2"
       }
     },
     "graphql-extensions": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.7.tgz",
-      "integrity": "sha512-xiTbVGPUpLbF86Bc+zxI/v/axRkwZx3s+y2/kUb2c2MxNZeNhMZEw1dSutuhY2f2JkRkYFJii0ucjIVqPAQ/Lg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.8.0.tgz",
+      "integrity": "sha512-zV9RefkusIXqi9ZJtl7IJ5ecjDKdb7PLAb5E3CmxX3OK1GwNCIubp0vE7Fp4fXlCUKgTB1Woubs0zj71JT8o0A==",
       "requires": {
         "@apollographql/apollo-tools": "^0.3.6",
-        "apollo-server-env": "2.4.0"
+        "apollo-server-env": "2.4.0",
+        "apollo-server-types": "0.2.0"
+      },
+      "dependencies": {
+        "@apollographql/apollo-tools": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.7.tgz",
+          "integrity": "sha512-+ertvzAwzkYmuUtT8zH3Zi6jPdyxZwOgnYaZHY7iLnMVJDhQKWlkyjLMF8wyzlPiEdDImVUMm5lOIBZo7LkGlg==",
+          "requires": {
+            "apollo-env": "0.5.1"
+          }
+        }
       }
     },
     "graphql-iso-date": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dotenv": "^6.2.0",
     "esm": "^3.2.25",
     "express": "^4.17.1",
-    "graphql": "~14.2.1",
+    "graphql": "~14.4.2",
     "graphql-iso-date": "^3.5.0",
     "graphql-tools": "^4.0.5",
     "graphql-type-json": "^0.2.4",


### PR DESCRIPTION
This pull request fixes another one of those competing `graphql` dependency errors (see the [build failure](https://circleci.com/gh/DoSomething/graphql/697) and additional context in #110).