### PR TITLE
Adds CampaignWebsite callToAction, coverImage

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -67,6 +67,8 @@ const typeDefs = gql`
     title: String!
     "The slug for this campaign."
     slug: String!
+     "The call to action tagline for this campaign."
+    callToAction: String!
     ${entryFields}
   }
 

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -69,6 +69,8 @@ const typeDefs = gql`
     slug: String!
      "The call to action tagline for this campaign."
     callToAction: String!
+    "The cover image for this campaign."
+    coverImage: Asset
     ${entryFields}
   }
 
@@ -314,6 +316,9 @@ const resolvers = {
   },
   Block: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
+  },
+  CampaignWebsite: {
+    coverImage: linkResolver,
   },
   TextSubmissionBlock: {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,


### PR DESCRIPTION
Adds Phoenix Contentful fields needed for the Referral Page (refs https://github.com/DoSomething/phoenix-next/pull/1521)

Example request:
```
{
  campaignWebsiteByCampaignId(campaignId:"9002") {
    title
    slug
    callToAction
    coverImage {
      id
      url
    }
  }
}
```

Example response:
```
{
  "data": {
    "campaignWebsiteByCampaignId": {
      "title": "Example Campaign",
      "slug": "test-example-campaign",
      "callToAction": "This is an example campaign for automated testing.",
      "coverImage": {
        "id": "GR8DbT1SjipEOZ1ey0qQd",
        "url": "https://images.ctfassets.net/81iqaqpfd8fy/GR8DbT1SjipEOZ1ey0qQd/da707c867e8bdb1522facdaac0a8a768/69146-istock-910939920.webp?f=center"
      }
    }
  },
  ...
```