### PR TITLE
Properly fetch the secondary cache key fields from webhook payload 🤦‍♂️

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -61,7 +61,7 @@ exports.handler = async event => {
     for (let i = 0; i < cacheKeys.length; i++) {
       const cacheKey = cacheKeys[i];
       const fieldValue =
-        body.fields && body.fields['cacheKey'] && body.fields['cacheKey']['en-US'];
+        body.fields && body.fields[cacheKey] && body.fields[cacheKey]['en-US'];
 
       if (fieldValue) {
         // Clear from DynamoDB (and await to make sure this completes).


### PR DESCRIPTION
## What did you break this time Mendel?

This PR contains a quick 🐛 fix for something I introduced in https://github.com/DoSomething/graphql/pull/113 which in it of itself was a bug fix ♻️  

I accidentally added quotes around what is meant to be a variable reference, thus always invoking the literal `'cacheKey'` field from Contentful webhook payloads when attempting to find and clear secondary cache key values.

![me](https://media.giphy.com/media/zOvBKUUEERdNm/giphy.gif)