### PR TITLE
Add "UNREGISTERED" to voter reg enum

### DIFF
--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -47,6 +47,7 @@ const typeDefs = gql`
     CONFIRMED
     INELIGIBLE
     UNCERTAIN
+    UNREGISTERED
   }
 
   enum EmailSubscriptionTopic {


### PR DESCRIPTION
Quick fix to support badges! We are missing the "UNREGISTERED" option in the voter registration status enum.