### PR TITLE
Add support for optional fields in Northstar.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 schema.graphql
 lib/
+.vscode

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       ],
       "space-unary-ops": "off",
       "arrow-parens": "off",
-      "no-confusing-arrow": "off"
+      "no-confusing-arrow": "off",
+      "no-param-reassign": "off"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "graphql-api-gateway",
   "description": "An GraphQL API gateway for DoSomething.org services.",
   "scripts": {
-    "start": "nodemon -e js,html local.js",
+    "start": "nodemon --inspect -e js,html local.js",
     "start:production": "node local.js",
     "test": "npm run lint && npm run format:ci",
     "lint": "eslint --ext .js src",

--- a/src/loader.js
+++ b/src/loader.js
@@ -85,13 +85,15 @@ export default (context, preview = false) => {
       // The 'users' loader is a little special. It batches up all the unique
       // user IDs we've asked for, and returns a DataLoader for each one to
       // batch up all the fields we're reading for each particular user.
+      //
+      // See also: usersResolver in resolvers/northstar.js.
       users: new DataLoader(async ids =>
         ids.map(
           id =>
             new DataLoader(async fields => {
               // We run this once per user w/ all their queried fields,
               // and then cache each resolved field in this user's loader.
-              const result = await getUserById(id, fields, options);
+              const result = await getUserById(id, fields, context);
               return fields.map(field => get(result, field));
             }),
         ),

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -1,15 +1,5 @@
 import { URL, URLSearchParams } from 'url';
-import {
-  flatMap,
-  map,
-  mapKeys,
-  has,
-  camelCase,
-  omit,
-  isUndefined,
-  isNil,
-  zipObject,
-} from 'lodash';
+import { map, mapKeys, has, camelCase, omit, isUndefined } from 'lodash';
 
 /**
  * Attach the user's authorization token to a request.
@@ -108,63 +98,3 @@ export const urlWithQuery = (path, args) => {
     return null;
   }
 };
-
-/**
- * Determine the fields that were requested for an item, via the query's
- * AST provided in the resolver's `info` argument. <dfurn.es/30usMgs>
- *
- * @param {GraphQLResolveInfo} info
- * @return {string[]}
- */
-export const getSelection = info => info.fieldNodes[0].selectionSet.selections;
-
-/**
- * Get a list of fields that we should query from the backend.
- *
- * @param {GraphQLResolveInfo} info
- * @return {string[]}
- */
-export const queriedFields = info => {
-  const type = info.schema.getType(info.returnType.name);
-  const fields = type.getFields();
-
-  return flatMap(getSelection(info), field => {
-    const name = field.name.value;
-
-    // Optionally, the `@requires` directive can be used to
-    // specify a custom mapping of GraphQL->REST fields:
-    return fields[name].requiredHttpIncludes || name;
-  });
-};
-
-/**
- * Keep track of any `@sensitive` fields that must be specifically
- * queried using the `?include=` query string on our REST APIs.
- *
- * @param {GraphQLResolveInfo} info
- * @return {string[]}
- */
-export const markSensitiveFieldsInContext = (info, context) => {
-  if (!context.optionalFields) {
-    context.optionalFields = {};
-  }
-
-  const type = info.schema.getType(info.returnType.name);
-  if (!context.optionalFields[type]) {
-    const fields = type.getFields();
-
-    context.optionalFields[type] = getSelection(info)
-      .map(field => field.name.value)
-      .filter(field => fields[field].isSensitive);
-  }
-};
-
-/**
- * Zip the provided list of fields & values, unless all the provided
- * values are `null` (in which case the item must have 404'd).
- *
- * @param {string[]} fields
- * @param {any[]} values
- */
-export const zipUnlessEmpty = (fields, values) =>
-  values.every(isNil) ? null : zipObject(fields, values);

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -138,6 +138,28 @@ export const queriedFields = info => {
 };
 
 /**
+ * Keep track of any `@sensitive` fields that must be specifically
+ * queried using the `?include=` query string on our REST APIs.
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
+export const markSensitiveFieldsInContext = (info, context) => {
+  if (!context.optionalFields) {
+    context.optionalFields = {};
+  }
+
+  const type = info.schema.getType(info.returnType.name);
+  if (!context.optionalFields[type]) {
+    const fields = type.getFields();
+
+    context.optionalFields[type] = getSelection(info)
+      .map(field => field.name.value)
+      .filter(field => fields[field].isSensitive);
+  }
+};
+
+/**
  * Zip the provided list of fields & values, unless all the provided
  * values are `null` (in which case the item must have 404'd).
  *

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -1,9 +1,9 @@
 import { URL, URLSearchParams } from 'url';
 import {
-  get,
-  has,
+  flatMap,
   map,
   mapKeys,
+  has,
   camelCase,
   omit,
   isUndefined,
@@ -117,14 +117,15 @@ export const urlWithQuery = (path, args) => {
  * @return {string[]}
  */
 export const queriedFields = info => {
-  const mapping = {
-    hasFeatureFlag: 'featureFlags',
-  };
+  const type = info.schema.getType(info.returnType.name);
+  const fields = type.getFields();
 
-  return info.fieldNodes[0].selectionSet.selections.map(field => {
-    const fieldName = field.name.value;
+  return flatMap(info.fieldNodes[0].selectionSet.selections, field => {
+    const name = field.name.value;
 
-    return get(mapping, fieldName, fieldName);
+    // Optionally, the `@requires` directive can be used to
+    // specify a custom mapping of GraphQL->REST fields:
+    return fields[name].requiredHttpIncludes || name;
   });
 };
 

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -116,11 +116,19 @@ export const urlWithQuery = (path, args) => {
  * @param {GraphQLResolveInfo} info
  * @return {string[]}
  */
+export const getSelection = info => info.fieldNodes[0].selectionSet.selections;
+
+/**
+ * Get a list of fields that we should query from the backend.
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
 export const queriedFields = info => {
   const type = info.schema.getType(info.returnType.name);
   const fields = type.getFields();
 
-  return flatMap(info.fieldNodes[0].selectionSet.selections, field => {
+  return flatMap(getSelection(info), field => {
     const name = field.name.value;
 
     // Optionally, the `@requires` directive can be used to

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -116,8 +116,17 @@ export const urlWithQuery = (path, args) => {
  * @param {GraphQLResolveInfo} info
  * @return {string[]}
  */
-export const queriedFields = info =>
-  info.fieldNodes[0].selectionSet.selections.map(field => field.name.value);
+export const queriedFields = info => {
+  const mapping = {
+    hasFeatureFlag: 'featureFlags',
+  };
+
+  return info.fieldNodes[0].selectionSet.selections.map(field => {
+    const fieldName = field.name.value;
+
+    return get(mapping, fieldName, fieldName);
+  });
+};
 
 /**
  * Zip the provided list of fields & values, unless all the provided

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -98,3 +98,13 @@ export const urlWithQuery = (path, args) => {
     return null;
   }
 };
+
+/**
+ * Determine the fields that were requested for an item, via the query's
+ * AST provided in the resolver's `info` argument. <dfurn.es/30usMgs>
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
+export const queriedFields = info =>
+  info.fieldNodes[0].selectionSet.selections.map(field => field.name.value);

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -1,5 +1,15 @@
-import { has, map, mapKeys, camelCase, omit, isUndefined } from 'lodash';
 import { URL, URLSearchParams } from 'url';
+import {
+  get,
+  has,
+  map,
+  mapKeys,
+  camelCase,
+  omit,
+  isUndefined,
+  isNil,
+  zipObject,
+} from 'lodash';
 
 /**
  * Attach the user's authorization token to a request.
@@ -108,3 +118,13 @@ export const urlWithQuery = (path, args) => {
  */
 export const queriedFields = info =>
   info.fieldNodes[0].selectionSet.selections.map(field => field.name.value);
+
+/**
+ * Zip the provided list of fields & values, unless all the provided
+ * values are `null` (in which case the item must have 404'd).
+ *
+ * @param {string[]} fields
+ * @param {any[]} values
+ */
+export const zipUnlessEmpty = (fields, values) =>
+  values.every(isNil) ? null : zipObject(fields, values);

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -1,19 +1,51 @@
+import { stringify } from 'qs';
 import logger from 'heroku-logger';
+import { intersection, snakeCase } from 'lodash';
 
+import Loader from '../loader';
 import config from '../../config';
-import { transformItem, requireAuthorizedRequest } from './helpers';
+import {
+  transformItem,
+  requireAuthorizedRequest,
+  queriedFields,
+  zipUnlessEmpty,
+} from './helpers';
 
 const NORTHSTAR_URL = config('services.northstar.url');
+
+// The list of fields that we'll need to query via `?include=`.
+// See '$sensitive' in Northstar's User model. <https://git.io/fjAFE>
+const OPTIONAL_USER_FIELDS = [
+  'email',
+  'mobile',
+  'lastName',
+  'addrStreet1',
+  'addrStreet2',
+  'birthdate',
+];
 
 /**
  * Fetch a user from Northstar by ID.
  *
  * @return {Object}
  */
-export const getUserById = async (id, options) => {
-  logger.debug('Loading user from Northstar', { id });
+export const getUserById = async (id, fields = [], options) => {
+  const optionalFields = intersection(fields, OPTIONAL_USER_FIELDS);
+
+  // Northstar expects a comma-separated list of snake_case fields.
+  // If not querying anything, use 'undefined' to omit query string.
+  const include = optionalFields.length
+    ? optionalFields.map(snakeCase).join()
+    : undefined;
+
+  logger.debug('Loading user from Northstar', { id, include });
+
   try {
-    const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}`, options);
+    const response = await fetch(
+      `${NORTHSTAR_URL}/v2/users/${id}?${stringify({ include })}`,
+      options,
+    );
+
     const json = await response.json();
 
     return transformItem(json);
@@ -23,6 +55,21 @@ export const getUserById = async (id, options) => {
   }
 
   return null;
+};
+
+/**
+ * Fetch users from Northstar by IDs.
+ *
+ * @return {Object}
+ */
+export const usersResolver = async (_, { id }, context, info) => {
+  const fields = queriedFields(info);
+  console.log(fields);
+
+  return Loader(context)
+    .users.load(id)
+    .then(user => user.loadMany(fields))
+    .then(values => zipUnlessEmpty(fields, values));
 };
 
 /**

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -2,15 +2,11 @@ import { stringify } from 'qs';
 import logger from 'heroku-logger';
 import { intersection, snakeCase } from 'lodash';
 
-import Loader from '../loader';
 import config from '../../config';
 import {
   transformItem,
-  queriedFields,
-  zipUnlessEmpty,
   authorizedRequest,
   requireAuthorizedRequest,
-  markSensitiveFieldsInContext,
 } from './helpers';
 
 const NORTHSTAR_URL = config('services.northstar.url');
@@ -44,22 +40,6 @@ export const getUserById = async (id, fields, context) => {
   }
 
   return null;
-};
-
-/**
- * Fetch users from Northstar by IDs.
- *
- * @return {Object}
- */
-export const usersResolver = async (_, { id }, context, info) => {
-  markSensitiveFieldsInContext(info, context);
-
-  const fields = queriedFields(info);
-
-  return Loader(context)
-    .users.load(id)
-    .then(user => user.loadMany(fields))
-    .then(values => zipUnlessEmpty(fields, values));
 };
 
 /**

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -64,7 +64,6 @@ export const getUserById = async (id, fields = [], options) => {
  */
 export const usersResolver = async (_, { id }, context, info) => {
   const fields = queriedFields(info);
-  console.log(fields);
 
   return Loader(context)
     .users.load(id)

--- a/src/schema/directives/RequiresDirective.js
+++ b/src/schema/directives/RequiresDirective.js
@@ -3,7 +3,7 @@ import { SchemaDirectiveVisitor } from 'graphql-tools';
 
 class RequiresDirective extends SchemaDirectiveVisitor {
   visitFieldDefinition(field) {
-    field.requiredHttpIncludes = this.args.fields;
+    set(field, 'requiredHttpIncludes', this.args.fields);
   }
 }
 

--- a/src/schema/directives/RequiresDirective.js
+++ b/src/schema/directives/RequiresDirective.js
@@ -1,9 +1,8 @@
-import { set } from 'lodash';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
 
 class RequiresDirective extends SchemaDirectiveVisitor {
   visitFieldDefinition(field) {
-    set(field, 'requiredHttpIncludes', this.args.fields);
+    field.requiredHttpIncludes = this.args.fields;
   }
 }
 

--- a/src/schema/directives/RequiresDirective.js
+++ b/src/schema/directives/RequiresDirective.js
@@ -1,0 +1,10 @@
+import { set } from 'lodash';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+
+class RequiresDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    field.requiredHttpIncludes = this.args.fields;
+  }
+}
+
+export default RequiresDirective;

--- a/src/schema/directives/SensitiveFieldDirective.js
+++ b/src/schema/directives/SensitiveFieldDirective.js
@@ -1,7 +1,6 @@
 /* Disabling this linting rule since we're conforming to an API. */
 /* eslint-disable class-methods-use-this */
 
-import { set } from 'lodash';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
 
 const HELP_TEXT =
@@ -9,8 +8,8 @@ const HELP_TEXT =
 
 class SensitiveFieldDirective extends SchemaDirectiveVisitor {
   visitFieldDefinition(field) {
-    set(field, 'isSensitive', true);
-    set(field, 'description', `${field.description} ${HELP_TEXT}`);
+    field.isSensitive = true;
+    field.description = `${field.description} ${HELP_TEXT}`;
   }
 }
 

--- a/src/schema/directives/SensitiveFieldDirective.js
+++ b/src/schema/directives/SensitiveFieldDirective.js
@@ -1,0 +1,17 @@
+/* Disabling this linting rule since we're conforming to an API. */
+/* eslint-disable class-methods-use-this */
+
+import { set } from 'lodash';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+
+const HELP_TEXT =
+  '**This field contains personally-identifiable information, and access will be logged.**';
+
+class SensitiveFieldDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    set(field, 'isSensitive', true);
+    set(field, 'description', `${field.description} ${HELP_TEXT}`);
+  }
+}
+
+export default SensitiveFieldDirective;

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { isNil, flatMap, zipObject, values } from 'lodash';
+import { flatMap, get, isNil, values, zipObject } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.
@@ -52,7 +52,7 @@ export const queriedFields = info => {
 
     // Optionally, the `@requires` directive can be used to
     // specify a custom mapping of GraphQL->REST fields:
-    return fields[name].requiredHttpIncludes || name;
+    return get(fields, `${name}.requiredHttpIncludes`, name);
   });
 };
 

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -81,11 +81,11 @@ export const markSensitiveFieldsInContext = (info, context) => {
 };
 
 /**
- * Zip the provided list of fields & values, unless all the provided
+ * Zip the provided list of keys & entries, unless all the provided
  * values are `null` (in which case the item must have 404'd).
  *
- * @param {string[]} fields
- * @param {any[]} values
+ * @param {string[]} keys
+ * @param {any[]} entries
  */
-export const zipUnlessEmpty = (fields, values) =>
-  values.every(isNil) ? null : zipObject(fields, values);
+export const zipUnlessEmpty = (keys, entries) =>
+  entries.every(isNil) ? null : zipObject(keys, entries);

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { isNil, flatMap, zipObject } from 'lodash';
+import { isNil, flatMap, zipObject, values } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.
@@ -74,9 +74,9 @@ export const markSensitiveFieldsInContext = (info, context) => {
   if (!context.optionalFields[type]) {
     const fields = type.getFields();
 
-    context.optionalFields[type] = getSelection(info)
-      .map(field => field.name.value)
-      .filter(field => fields[field].isSensitive);
+    context.optionalFields[type] = values(fields)
+      .filter(field => field.isSensitive)
+      .map(field => field.name);
   }
 };
 

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -25,5 +25,3 @@ export const listToEnums = list => {
 
   return list.map(stringToEnum);
 };
-
-export default null;

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -68,6 +68,8 @@ export const markSensitiveFieldsInContext = (info, context) => {
     context.optionalFields = {};
   }
 
+  // If this is the first time we're resolving this type (e.g. User)
+  // mark any `@sensitive` fields in the context for later:
   const type = info.schema.getType(info.returnType.name);
   if (!context.optionalFields[type]) {
     const fields = type.getFields();

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,3 +1,5 @@
+import { isNil, flatMap, zipObject } from 'lodash';
+
 /**
  * Transform a string constant into a GraphQL-style enum.
  *
@@ -25,3 +27,63 @@ export const listToEnums = list => {
 
   return list.map(stringToEnum);
 };
+
+/**
+ * Determine the fields that were requested for an item, via the query's
+ * AST provided in the resolver's `info` argument. <dfurn.es/30usMgs>
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
+export const getSelection = info => info.fieldNodes[0].selectionSet.selections;
+
+/**
+ * Get a list of fields that we should query from the backend.
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
+export const queriedFields = info => {
+  const type = info.schema.getType(info.returnType.name);
+  const fields = type.getFields();
+
+  return flatMap(getSelection(info), field => {
+    const name = field.name.value;
+
+    // Optionally, the `@requires` directive can be used to
+    // specify a custom mapping of GraphQL->REST fields:
+    return fields[name].requiredHttpIncludes || name;
+  });
+};
+
+/**
+ * Keep track of any `@sensitive` fields that must be specifically
+ * queried using the `?include=` query string on our REST APIs.
+ *
+ * @param {GraphQLResolveInfo} info
+ * @return {string[]}
+ */
+export const markSensitiveFieldsInContext = (info, context) => {
+  if (!context.optionalFields) {
+    context.optionalFields = {};
+  }
+
+  const type = info.schema.getType(info.returnType.name);
+  if (!context.optionalFields[type]) {
+    const fields = type.getFields();
+
+    context.optionalFields[type] = getSelection(info)
+      .map(field => field.name.value)
+      .filter(field => fields[field].isSensitive);
+  }
+};
+
+/**
+ * Zip the provided list of fields & values, unless all the provided
+ * values are `null` (in which case the item must have 404'd).
+ *
+ * @param {string[]} fields
+ * @param {any[]} values
+ */
+export const zipUnlessEmpty = (fields, values) =>
+  values.every(isNil) ? null : zipObject(fields, values);

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -4,9 +4,11 @@ import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 import { has } from 'lodash';
 
-import Loader from '../loader';
 import { stringToEnum, listToEnums } from './helpers';
-import { updateEmailSubscriptionTopics } from '../repositories/northstar';
+import {
+  usersResolver,
+  updateEmailSubscriptionTopics,
+} from '../repositories/northstar';
 
 /**
  * GraphQL types.
@@ -158,7 +160,7 @@ const resolvers = {
       user.featureFlags[feature] !== false,
   },
   Query: {
-    user: (_, args, context) => Loader(context).users.load(args.id),
+    user: usersResolver,
   },
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -1,10 +1,11 @@
-import { makeExecutableSchema } from 'graphql-tools';
-import { gql } from 'apollo-server';
-import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
-import { GraphQLAbsoluteUrl } from 'graphql-url';
 import { has } from 'lodash';
+import { gql } from 'apollo-server';
+import { GraphQLAbsoluteUrl } from 'graphql-url';
+import { GraphQLDate, GraphQLDateTime } from 'graphql-iso-date';
+import { makeExecutableSchema } from 'graphql-tools';
 
 import { stringToEnum, listToEnums } from './helpers';
+import RequiresDirective from './directives/RequiresDirective';
 import {
   usersResolver,
   updateEmailSubscriptionTopics,
@@ -21,6 +22,8 @@ const typeDefs = gql`
   scalar DateTime
 
   scalar AbsoluteUrl
+
+  directive @requires(fields: [String]!) on FIELD_DEFINITION
 
   "The user's role defines their abilities on any DoSomething.org site."
   enum Role {
@@ -125,7 +128,7 @@ const typeDefs = gql`
     "What time of day user plans to get the polls to vote in upcoming election."
     votingPlanTimeOfDay: String
     "Whether or not the user is opted-in to the given feature."
-    hasFeatureFlag(feature: String): Boolean
+    hasFeatureFlag(feature: String): Boolean @requires(fields: ["featureFlags"])
   }
 
   type Query {
@@ -183,4 +186,7 @@ const resolvers = {
 export default makeExecutableSchema({
   typeDefs,
   resolvers,
+  schemaDirectives: {
+    requires: RequiresDirective,
+  },
 });

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -6,6 +6,7 @@ import { makeExecutableSchema } from 'graphql-tools';
 
 import { stringToEnum, listToEnums } from './helpers';
 import RequiresDirective from './directives/RequiresDirective';
+import SensitiveFieldDirective from './directives/SensitiveFieldDirective';
 import {
   usersResolver,
   updateEmailSubscriptionTopics,
@@ -24,6 +25,8 @@ const typeDefs = gql`
   scalar AbsoluteUrl
 
   directive @requires(fields: [String]!) on FIELD_DEFINITION
+
+  directive @sensitive on FIELD_DEFINITION
 
   "The user's role defines their abilities on any DoSomething.org site."
   enum Role {
@@ -70,19 +73,19 @@ const typeDefs = gql`
     "The user's first name."
     firstName: String
     "The user's last name."
-    lastName: String
+    lastName: String @sensitive
     "The user's last initial."
     lastInitial: String
     "The user's email address."
-    email: String
+    email: String @sensitive
     "The user's mobile number."
-    mobile: String
+    mobile: String @sensitive
     "The user's birthdate, formatted YYYY-MM-DD."
-    birthdate: Date
+    birthdate: Date @sensitive
     "The user's street address. Null if unauthorized."
-    addrStreet1: String
+    addrStreet1: String @sensitive
     "The user's extended street address (for example, apartment number). Null if unauthorized."
-    addrStreet2: String
+    addrStreet2: String @sensitive
     "The user's city. Null if unauthorized."
     addrCity: String
     "The user's state. Null if unauthorized."
@@ -188,5 +191,6 @@ export default makeExecutableSchema({
   resolvers,
   schemaDirectives: {
     requires: RequiresDirective,
+    sensitive: SensitiveFieldDirective,
   },
 });


### PR DESCRIPTION
This pull request revisits the work done in #124 to allow GraphQL to query our new optional fields in Northstar, which we had to [revert because of a surprise bug](https://github.com/DoSomething/graphql/pull/127) that was blocking the badges launch.

### Background:
We're removing fields with sensitive information from standard (authorized) API responses as part of the [Access Control & Auditing](https://docs.google.com/document/d/1OclKWYEtjo0LTI9DzKaVG1dEBY6kfAEEgYZVRzSlD7s/edit) work happening this quarter. So, for example, `/users/:id` in Northstar would only include `addr_street1` if the `?include=addr_street1` query string is provided.

By only sending sensitive fields like `addr_street1` when they're actually used, we can then easily audit usage by logging those API requests directly in Northstar or Rogue.

### Why is this hard?
I'd originally assumed this would be dead-simple (whoops) since we always know the full query in GraphQL. Heck, that's like the whole idea! Parsing the requested fields from the query was not well-documented, but [ultimately not hard](https://github.com/DoSomething/graphql/commit/b2537cd519f4c160e5bac613d890114d78592c77).

One of the important things we rely on our GraphQL server for is batching requests (so for example, loading a gallery of my posts should only end up making _one_ request for my profile to fill in each posts' "first name" label). We handle this with [DataLoader](https://github.com/graphql/dataloader), which collects a bunch of `dataLoader.find('…id…')` calls, creates a single Promise per unique ID, and then passes the batch of unique IDs to a single ["batch loader" function](https://github.com/graphql/dataloader#batch-function).

The problem we've run into here is that we now have a "two-part" key, since instead of grouping a bunch of `SELECT * FROM users WHERE id = 123` calls, we're now also trying to combine `SELECT first_name, email FROM users WHERE id = 123` and `SELECT addr_street1 FROM users WHERE id = 123` into `SELECT first_name, email, addr_street1 FROM users WHERE id = 123`. Unfortunately, DataLoader doesn't have an easy answer for this use-case!

### Recap: How'd we get here?
I'd originally tried to implement this [by passing ID/field combos & de-duping in the users loader's `batchFunction`](https://github.com/graphql/dataloader#batch-function) (af07f28). But since we handled batching ourselves later in the process, re-requesting a previously loaded user with a different subset of the previously requested fields wouldn't read from DataLoader's cache (since `dataLoader.find({id: 'a', fields: 'firstName', 'lastName'})` and `dataLoader.find({id: 'a', fields: 'firstName'})` are not the "same" key, even though the second one is satisfied by the first).

My next approach was to see if we could use [the `cacheKeyFn` option](https://github.com/graphql/dataloader#new-dataloaderbatchloadfn--options) to tell DataLoader how to batch up requests (e.g. `key => key.id`), but that just ended up discarding all subsequent loads with different fields. I also tried making a custom [cacheMap implementation](https://github.com/graphql/dataloader#new-dataloaderbatchloadfn--options) (cba31f5473b286cdd0a471585762ea14a9f98358), but ran into a similar problem – we'd create a new Promise for the first time we saw a new user ID, but had no good way to "merge" in new fields to an existing (pending) promise if we requested more fields on that same user later on.

I finally settled on using nested DataLoaders – one to batch up all the IDs we asked for in a query, and then another DataLoader for each unique ID to batch up the fields we'd selected. This seemed to work well when testing things out at first, and (unlike before) didn't conflict with DataLoader's expectations on how it'd be used for batching/caching!

### The New Problem
Mendel & I [noticed two smaller bugs](https://github.com/DoSomething/graphql/pull/124#issuecomment-525879091) that didn't seem blocking. The second one ended up being a bigger deal than I'd thought, though! Since we're now only storing each directly queried field, we can't read from any fields in Northstar's response that aren't explicitly requested:

```gql
user(id: "…") {
  hasFeatureFlag(flag: "badges") # reads from the 'feature_flags' object on the user response.
}
```

I had thought we could [prime the DataLoader](https://github.com/graphql/dataloader#primekey-value) with any fields returned by Northstar that we didn't originally query, but this still doesn't end up getting it into the [user resolver return value](https://github.com/DoSomething/graphql/pull/124/files#diff-438e69f9ee594260d8e533cbee5e10a2R65) that's read [here](https://github.com/DoSomething/graphql/blob/43e6457473c07c7d51d16f3a19359cb1ca561c66/src/schema/northstar.js#L158-L160). To do that, we'd probably need to add an override [to include `feature_flags` in the "queried fields" helper in place of `hasFeatureFlag`](https://github.com/DoSomething/graphql/pull/124/files#diff-438e69f9ee594260d8e533cbee5e10a2R60)... which doesn't feel great. Hmm...