### PR TITLE
Fix edge-case where empty responses would be considered "not found".

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -94,7 +94,14 @@ export default (context, preview = false) => {
               // We run this once per user w/ all their queried fields,
               // and then cache each resolved field in this user's loader.
               const result = await getUserById(id, fields, context);
-              return fields.map(field => get(result, field));
+
+              // If this resource 404'd, return an array of 'undefined' fields
+              // to signal to the resolver that this resource doesn't exist.
+              if (!result) {
+                return fields.map(() => undefined);
+              }
+
+              return fields.map(field => get(result, field, null));
             }),
         ),
       ),

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { flatMap, get, isNil, values, zipObject } from 'lodash';
+import { flatMap, get, isUndefined, values, zipObject } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.
@@ -88,4 +88,4 @@ export const markSensitiveFieldsInContext = (info, context) => {
  * @param {any[]} entries
  */
 export const zipUnlessEmpty = (keys, entries) =>
-  entries.every(isNil) ? null : zipObject(keys, entries);
+  entries.every(isUndefined) ? null : zipObject(keys, entries);


### PR DESCRIPTION
This pull request fixes an issue [that @aaronschachter flagged yesterday](https://dosomething.slack.com/archives/C3ASB4204/p1567718596068800?thread_ts=1567712576.065400&cid=C3ASB4204)) where queries that had only null values in the response would be considered the same as a "not found" resource.

The fix was to differentiate between an altogether not-found resource by returning an array of `undefined`s, whereas something that _did_ exist but just didn't have that field will now be `null`. This isn't super elegant, but is the solution I can find for our nested DataLoaders.