### PR TITLE
Refactor "optional fields" work to be more readable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
       "space-unary-ops": "off",
       "arrow-parens": "off",
       "no-confusing-arrow": "off",
-      "no-param-reassign": "off"
+      "no-param-reassign": "off",
+      "class-methods-use-this": "off"
     }
   },
   "dependencies": {

--- a/src/FieldDataLoader.js
+++ b/src/FieldDataLoader.js
@@ -1,0 +1,70 @@
+import { get, isUndefined, zipObject } from 'lodash';
+import DataLoader from 'dataloader';
+
+class FieldDataLoader {
+  constructor(batchFunction, options = {}) {
+    // Configure our nested loaders (woah) for this type of item. Optionally,
+    // configure batch/caching settings for the item loader:
+    this.loader = new DataLoader(
+      async ids =>
+        ids.map(
+          id =>
+            new DataLoader(async fields => {
+              // We'll call `batchFunction` once per unique ID, with all the unique
+              // fields we've requested for that ID within this request:
+              const result = await batchFunction(id, fields);
+
+              // DataLoader requires the same signature for the batched input & ouput,
+              // but we might have a scenario where the given ID isn't found. To handle
+              // that, we'll return an appropriately sized array of 'undefined' values
+              // here & then zip it back up in our 'load' function below:
+              if (!result) {
+                return fields.map(() => undefined);
+              }
+
+              // Otherwise, we'll return an array of values corresponding to the requested
+              // fields. If the item exists, but a field doesn't, we'll return `null`.
+              return fields.map(field => get(result, field, null));
+            }),
+        ),
+      options,
+    );
+  }
+
+  load(key, fields) {
+    return this.loader
+      .load(key)
+      .then(item => item.loadMany(fields))
+      .then(values => {
+        // If this resource 404'd, return `null` (see above).
+        if (values.every(isUndefined)) {
+          return null;
+        }
+
+        // Otherwise, zip the loaded fields back into an object:
+        return zipObject(fields, values);
+      });
+  }
+
+  loadMany() {
+    // @TODO: Eventually, we should support the same API as DataLoader!
+    throw new Error('Not supported.');
+  }
+
+  clear() {
+    // @TODO: Eventually, we should support the same API as DataLoader!
+    throw new Error('Not yet implemented.');
+  }
+
+  clearAll() {
+    // @TODO: Eventually, we should support the same API as DataLoader!
+    throw new Error('Not yet implemented.');
+  }
+
+  prime() {
+    // @TODO: Eventually, we should support the same API as DataLoader!
+    throw new Error('Not yet implemented.');
+  }
+}
+
+export default FieldDataLoader;

--- a/src/schema/directives/HasSensitiveFieldsDirective.js
+++ b/src/schema/directives/HasSensitiveFieldsDirective.js
@@ -1,0 +1,31 @@
+import { values } from 'lodash';
+import { defaultFieldResolver } from 'graphql';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+
+class SensitiveFieldDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+
+    field.resolve = async (source, args, context, info) => {
+      // If this is the first time this has run, initialize:
+      if (!context.optionalFields) {
+        context.optionalFields = {};
+      }
+
+      // Get the return type for this field:
+      const type = info.schema.getType(info.returnType.name);
+
+      // If this is the first time we're resolving this type (e.g. User)
+      // mark any `@sensitive` fields in the context for later:
+      if (!context.optionalFields[type]) {
+        context.optionalFields[type] = values(type.getFields())
+          .filter(subfield => subfield.isSensitive)
+          .map(subfield => subfield.name);
+      }
+
+      return resolve.call(this, source, args, context, info);
+    };
+  }
+}
+
+export default SensitiveFieldDirective;

--- a/src/schema/directives/SensitiveFieldDirective.js
+++ b/src/schema/directives/SensitiveFieldDirective.js
@@ -1,6 +1,3 @@
-/* Disabling this linting rule since we're conforming to an API. */
-/* eslint-disable class-methods-use-this */
-
 import { SchemaDirectiveVisitor } from 'graphql-tools';
 
 const HELP_TEXT =

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { flatMap, get, values } from 'lodash';
+import { flatMap, get } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { flatMap, get, isUndefined, values, zipObject } from 'lodash';
+import { flatMap, get, values } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.
@@ -79,13 +79,3 @@ export const markSensitiveFieldsInContext = (info, context) => {
       .map(field => field.name);
   }
 };
-
-/**
- * Zip the provided list of keys & entries, unless all the provided
- * values are `null` (in which case the item must have 404'd).
- *
- * @param {string[]} keys
- * @param {any[]} entries
- */
-export const zipUnlessEmpty = (keys, entries) =>
-  entries.every(isUndefined) ? null : zipObject(keys, entries);

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -55,27 +55,3 @@ export const queriedFields = info => {
     return get(fields, `${name}.requiredHttpIncludes`, name);
   });
 };
-
-/**
- * Keep track of any `@sensitive` fields that must be specifically
- * queried using the `?include=` query string on our REST APIs.
- *
- * @param {GraphQLResolveInfo} info
- * @return {string[]}
- */
-export const markSensitiveFieldsInContext = (info, context) => {
-  if (!context.optionalFields) {
-    context.optionalFields = {};
-  }
-
-  // If this is the first time we're resolving this type (e.g. User)
-  // mark any `@sensitive` fields in the context for later:
-  const type = info.schema.getType(info.returnType.name);
-  if (!context.optionalFields[type]) {
-    const fields = type.getFields();
-
-    context.optionalFields[type] = values(fields)
-      .filter(field => field.isSensitive)
-      .map(field => field.name);
-  }
-};

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -170,10 +170,9 @@ const resolvers = {
   },
   Query: {
     user: (_, { id }, context, info) => {
-      const fields = queriedFields(info);
       markSensitiveFieldsInContext(info, context);
 
-      return Loader(context).users.load(id, fields);
+      return Loader(context).users.load(id, queriedFields(info));
     },
   },
   Date: GraphQLDate,

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -12,7 +12,6 @@ import {
   stringToEnum,
   listToEnums,
   queriedFields,
-  zipUnlessEmpty,
   markSensitiveFieldsInContext,
 } from './helpers';
 
@@ -174,10 +173,7 @@ const resolvers = {
       const fields = queriedFields(info);
       markSensitiveFieldsInContext(info, context);
 
-      return Loader(context)
-        .users.load(id)
-        .then(user => user.loadMany(fields))
-        .then(values => zipUnlessEmpty(fields, values));
+      return Loader(context).users.load(id, fields);
     },
   },
   Date: GraphQLDate,


### PR DESCRIPTION
This pull request extracts the implementation details of batching IDs & per-ID fields into a `FieldDataLoader` class that mimics `DataLoader`'s API, but with an additional `fields` argument for load. I think this make it a lot easier to follow how everything fits together (since it's all in one file), and the loader/resolver can _just_ worry about their traditional responsibilities.