### PR TITLE
Fix parsing null arrays of enums.

### DIFF
--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -22,7 +22,7 @@ export const stringToEnum = string => {
  */
 export const listToEnums = list => {
   if (!list) {
-    return null;
+    return [];
   }
 
   return list.map(stringToEnum);

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -100,7 +100,7 @@ const typeDefs = gql`
     "The user's email subscription status."
     emailSubscriptionStatus: Boolean
     "The user's email subscription status."
-    emailSubscriptionTopics: [EmailSubscriptionTopic]
+    emailSubscriptionTopics: [EmailSubscriptionTopic]!
     "The user's SMS status."
     smsStatus: SubscriptionStatus
     "The user's conversation status will be paused if they are in a support conversation."


### PR DESCRIPTION
This pull request fixes an issue where the "Badges" account tab would explode if a user didn't have any email subscriptions (because we'd return `null` for `emailSubscriptionTopics` and then [try to call `.includes`](https://github.com/DoSomething/phoenix-next/blob/8fec6f3014b72f921e9ef8d4da7e8936ba6c3b71/resources/assets/components/pages/AccountPage/BadgesTab.js#L258-L260) on it.

```
Uncaught TypeError: Cannot read property 'includes' of null
    at BadgesTab.js:258
```

Since it really doesn't make sense to have a `null` value for your list of subscriptions, let's make sure `listToEnums` defaults to an empty array & mark this as a non-nullable field in the schema.