### PR TITLE
Add 'displayName', 'emailPreview', 'mobilePreview', and 'permalink' to users.

### DIFF
--- a/config/services.js
+++ b/config/services.js
@@ -57,6 +57,11 @@ const environments = {
       url: process.env.LOCAL_NORTHSTAR_URL || 'http://northstar.test',
     },
 
+    // Aurora
+    aurora: {
+      url: process.env.LOCAL_AURORA_URL || 'http://aurora.test',
+    },
+
     // Rogue
     rogue: {
       url: process.env.LOCAL_ROGUE_URL || 'http://rogue.test',
@@ -86,6 +91,11 @@ const environments = {
     // Northstar
     northstar: {
       url: 'https://identity-dev.dosomething.org',
+    },
+
+    // Aurora
+    aurora: {
+      url: 'https://admin-dev.dosomething.org',
     },
 
     // Rogue
@@ -118,6 +128,11 @@ const environments = {
       url: 'https://identity-qa.dosomething.org',
     },
 
+    // Aurora
+    aurora: {
+      url: 'https://admin-qa.dosomething.org',
+    },
+
     // Rogue
     rogue: {
       url: 'https://activity-qa.dosomething.org',
@@ -146,6 +161,11 @@ const environments = {
     // Northstar
     northstar: {
       url: 'https://identity.dosomething.org',
+    },
+
+    // Aurora
+    aurora: {
+      url: 'https://admin.dosomething.org',
     },
 
     // Rogue

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -10,6 +10,7 @@ import {
 } from './helpers';
 
 const NORTHSTAR_URL = config('services.northstar.url');
+const AURORA_URL = config('services.aurora.url');
 
 /**
  * Fetch a user from Northstar by ID.
@@ -84,4 +85,10 @@ export const updateEmailSubscriptionTopics = async (
   return null;
 };
 
-export default null;
+/**
+ * Get Aurora profile permalink by ID.
+ *
+ * @param {String} id
+ * @return {String}
+ */
+export const getPermalinkByUserId = id => `${AURORA_URL}/users/${id}`;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -74,6 +74,8 @@ const typeDefs = gql`
   type User {
     "The user's Northstar ID."
     id: String!
+    "The user's display name is their first name and (if set) last initial."
+    displayName: String
     "The user's first name."
     firstName: String
     "The user's last name."
@@ -82,8 +84,12 @@ const typeDefs = gql`
     lastInitial: String
     "The user's email address."
     email: String @sensitive
+    "A preview of the user's email address."
+    emailPreview: String
     "The user's mobile number."
     mobile: String @sensitive
+    "A preview of the user's mobile number."
+    mobilePreview: String
     "The user's birthdate, formatted YYYY-MM-DD."
     birthdate: Date @sensitive
     "The user's street address. Null if unauthorized."

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -8,8 +8,11 @@ import { makeExecutableSchema } from 'graphql-tools';
 import Loader from '../loader';
 import SensitiveFieldDirective from './directives/SensitiveFieldDirective';
 import HasSensitiveFieldsDirective from './directives/HasSensitiveFieldsDirective';
-import { updateEmailSubscriptionTopics } from '../repositories/northstar';
 import { stringToEnum, listToEnums } from './helpers';
+import {
+  updateEmailSubscriptionTopics,
+  getPermalinkByUserId,
+} from '../repositories/northstar';
 
 /**
  * GraphQL types.
@@ -133,6 +136,8 @@ const typeDefs = gql`
     votingPlanTimeOfDay: String
     "Whether or not the user is opted-in to the given feature."
     hasFeatureFlag(feature: String): Boolean @requires(fields: "featureFlags")
+    "The permalink to this user's profile in Aurora."
+    permalink: String
   }
 
   type Query {
@@ -162,6 +167,7 @@ const resolvers = {
     smsStatus: user => stringToEnum(user.smsStatus),
     voterRegistrationStatus: user => stringToEnum(user.voterRegistrationStatus),
     emailSubscriptionTopics: user => listToEnums(user.emailSubscriptionTopics),
+    permalink: user => getPermalinkByUserId(user.id),
     hasFeatureFlag: (user, { feature }) =>
       has(user, `featureFlags.${feature}`) &&
       user.featureFlags[feature] !== false,


### PR DESCRIPTION
This pull request adds the following fields to the User schema:

- `displayName` (e.g. "David F.")
- `emailPreview` (e.g. "dfu...@dosomething.org")
- `mobilePreview` (e.g. "(203) 555-XXXX")
- `permalink` (the user's Aurora profile URL)