### PR TITLE
Fix issue loading 'permalink' without 'id'.

### DIFF
--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -143,7 +143,7 @@ const typeDefs = gql`
     "Whether or not the user is opted-in to the given feature."
     hasFeatureFlag(feature: String): Boolean @requires(fields: "featureFlags")
     "The permalink to this user's profile in Aurora."
-    permalink: String
+    permalink: String @requires(fields: "id")
   }
 
   type Query {


### PR DESCRIPTION
This fixes an issue in #136 when querying `permalink` without including `id` in the query (since it relies on that field to build the permalink). I've added a `@requires` so this now always works.