### PR TITLE
Add 'age' to User schema.

### DIFF
--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -90,6 +90,8 @@ const typeDefs = gql`
     mobile: String @sensitive
     "A preview of the user's mobile number."
     mobilePreview: String
+    "The user's age."
+    age: Int
     "The user's birthdate, formatted YYYY-MM-DD."
     birthdate: Date @sensitive
     "The user's street address. Null if unauthorized."


### PR DESCRIPTION
This pull request just adds the `age` field to the `User` schema. This is only available to authorized users (the user themselves or staff/admins).