### PR TITLE
Add a `users` query with search functionality.

### DIFF
--- a/src/schema/directives/HasSensitiveFieldsDirective.js
+++ b/src/schema/directives/HasSensitiveFieldsDirective.js
@@ -1,6 +1,7 @@
 import { values } from 'lodash';
 import { defaultFieldResolver } from 'graphql';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { isListType } from 'graphql/type/definition';
 
 class SensitiveFieldDirective extends SchemaDirectiveVisitor {
   visitFieldDefinition(field) {
@@ -13,7 +14,11 @@ class SensitiveFieldDirective extends SchemaDirectiveVisitor {
       }
 
       // Get the return type for this field:
-      const type = info.schema.getType(info.returnType.name);
+      const returnType = isListType(info.returnType)
+        ? info.returnType.ofType
+        : info.returnType.name;
+
+      const type = info.schema.getType(returnType);
 
       // If this is the first time we're resolving this type (e.g. User)
       // mark any `@sensitive` fields in the context for later:

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -12,6 +12,7 @@ import { stringToEnum, listToEnums } from './helpers';
 import {
   updateEmailSubscriptionTopics,
   getPermalinkByUserId,
+  getUsers,
 } from '../repositories/northstar';
 
 /**
@@ -151,6 +152,7 @@ const typeDefs = gql`
   type Query {
     "Get a user by ID."
     user(id: String!): User @hasSensitiveFields
+    users(search: String!): [User] @hasSensitiveFields
   }
 
   type Mutation {
@@ -183,6 +185,8 @@ const resolvers = {
   Query: {
     user: (_, { id }, context, info) =>
       Loader(context).users.load(id, getSelection(info)),
+    users: (_, args, context, info) =>
+      getUsers(args, getSelection(info), context),
   },
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,


### PR DESCRIPTION
This pull request adds a bare-bones `users` query with the ability to search by a given term, e.g. `users(search: "dfurnes@dosomething.org")`. This is something we use in admin interfaces, like Rogue or Aurora.

References [#169233808](https://www.pivotaltracker.com/story/show/169233808).