### PR TITLE
Fixes an issue querying the 'campaign' relationship on Signup.

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -376,8 +376,8 @@ const resolvers = {
     permalink: post => getPermalinkBySignupId(post.signupId),
   },
   Signup: {
-    campaign: (signup, args, context) =>
-      Loader(context).campaigns.load(signup.campaignId),
+    campaign: (signup, args, context, info) =>
+      Loader(context).campaigns.load(signup.campaignId, getSelection(info)),
     permalink: signup => getPermalinkBySignupId(signup.id),
     posts: (signup, args, context) => getPostsBySignupId(signup.id, context),
   },


### PR DESCRIPTION
This fixes an issue [flagged by @ngjo](https://dosomething.slack.com/archives/C02BBP0CU/p1572462359017000) [and @aaronschachter](https://dosomething.slack.com/archives/CAPHYCR8V/p1572462427014100) where loading the `campaign` field on a signup would fail (because it was missing the list of selected fields, required since #141).