### PR TITLE
Contentful Phoenix Cause Page

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -21,6 +21,7 @@ import {
   getPhoenixContentfulEntryById,
   getAffiliateByUtmLabel,
   getCampaignWebsiteByCampaignId,
+  getCausePageBySlug,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -75,6 +76,9 @@ export default (context, preview = false) => {
             getCampaignWebsiteByCampaignId(campaignId, context),
           ),
         ),
+      ),
+      causePagesBySlug: new DataLoader(slugs =>
+        Promise.all(slugs.map(slug => getCausePageBySlug(slug, context))),
       ),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -171,6 +171,20 @@ export const getCampaignWebsiteByCampaignId = async (campaignId, context) =>
   );
 
 /**
+ * Search for a Phoenix Contentful Cause Page entry by slug.
+ *
+ * @param {String} slug
+ * @return {Object}
+ */
+export const getCausePageBySlug = async (slug, context) =>
+  getPhoenixContentfulEntryByField(
+    'causePage',
+    'slug',
+    slug,
+    context,
+  );
+
+/**
  * Search for a Phoenix Contentful affiliate entry by utmLabel.
  *
  * @param {String} id

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -177,12 +177,7 @@ export const getCampaignWebsiteByCampaignId = async (campaignId, context) =>
  * @return {Object}
  */
 export const getCausePageBySlug = async (slug, context) =>
-  getPhoenixContentfulEntryByField(
-    'causePage',
-    'slug',
-    slug,
-    context,
-  );
+  getPhoenixContentfulEntryByField('causePage', 'slug', slug, context);
 
 /**
  * Search for a Phoenix Contentful affiliate entry by utmLabel.

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -122,6 +122,15 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type CausePage {
+    slug: String!
+    coverImage: Asset!
+    superTitle: String!
+    title: String!
+    description: JSON!
+    content: JSON!
+  }
+
   type ImagesBlock implements Block {
     "The images to be included in this block."
     images: [Asset]
@@ -383,6 +392,7 @@ const typeDefs = gql`
     campaignWebsite(id: String!, preview: Boolean = false): CampaignWebsite
     page(id: String!, preview: Boolean = false): Page
     campaignWebsiteByCampaignId(campaignId: String!, preview: Boolean = false): CampaignWebsite
+    causePageBySlug(slug: String!, preview: Boolean = false): CausePage
   }
 `;
 
@@ -407,6 +417,7 @@ const contentTypeMappings = {
   shareAction: 'ShareBlock',
   textSubmissionAction: 'TextSubmissionBlock',
   voterRegistrationAction: 'VoterRegistrationBlock',
+  causePage: 'CausePage',
 };
 
 /**
@@ -429,6 +440,8 @@ const resolvers = {
       Loader(context, preview).campaignWebsites.load(id),
     campaignWebsiteByCampaignId: (_, { campaignId, preview }, context) =>
       Loader(context, preview).campaignWebsiteByCampaignIds.load(campaignId),
+    causePageBySlug: (_, { slug, preview }, context) =>
+      Loader(context, preview).causePageBySlugs.load(slug),
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },
@@ -455,6 +468,9 @@ const resolvers = {
     showcaseDescription: campaign => campaign.callToAction,
     showcaseImage: (person, _, context, info) =>
       linkResolver(person, _, context, info, 'coverImage'),
+  },
+  CausePage: {
+    coverImage: linkResolver,
   },
   TextSubmissionBlock: {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -441,7 +441,7 @@ const resolvers = {
     campaignWebsiteByCampaignId: (_, { campaignId, preview }, context) =>
       Loader(context, preview).campaignWebsiteByCampaignIds.load(campaignId),
     causePageBySlug: (_, { slug, preview }, context) =>
-      Loader(context, preview).causePageBySlugs.load(slug),
+      Loader(context, preview).causePagesBySlug.load(slug),
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },

--- a/webhook.js
+++ b/webhook.js
@@ -52,6 +52,7 @@ exports.handler = async event => {
   const secondaryKeys = {
     affiliates: ['utmLabel'],
     campaign: ['legacyCampaignId'],
+    causePage: ['slug'],
   };
 
   // Clear secondary cache key results from the Contentful cache if applicable.


### PR DESCRIPTION
This PR adds a new `CausePage` type to our Phoenix Contentful schema for the new `causePage` Contentful content type https://github.com/DoSomething/phoenix-next/pull/1660

It also adds a new `getCausePageBySlug` so we can retrieve these directly from the Phoenix front end using the `:slug` in the URL (`/causes/:slug`) to find the correct Cause Page to surface.

I also named the loader correctly 😅 