### PR TITLE
Add 'Cause' type and 'Campaign.causes'.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -524,5 +524,16 @@ export const parseCampaignCauses = campaign => {
   // from Rogue's Campaigns API. We'll zip them together.
   const { cause, causeNames } = campaign;
 
+  // Some campaigns have badly-formatted data...
+  if (cause.length !== causeNames.length) {
+    logger.warn('Misformated campaign causes', {
+      id: campaign.id,
+      cause,
+      causeNames,
+    });
+
+    return [];
+  }
+
   return zipWith(cause, causeNames, (id, name) => ({ id, name }));
 };

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -2,7 +2,7 @@ import { stringify } from 'qs';
 import pluralize from 'pluralize';
 import logger from 'heroku-logger';
 import { getFields } from 'fielddataloader';
-import { find, has, intersection, snakeCase } from 'lodash';
+import { find, has, intersection, snakeCase, zipWith } from 'lodash';
 
 import schema from '../schema';
 import config from '../../config';
@@ -512,4 +512,17 @@ export const getPostsCount = async (args, context) => {
   const result = transformCollection(json);
 
   return result.length;
+};
+
+/**
+ * Parse `Cause` type from a given campaign.
+ *
+ * @param {Object} campaign
+ */
+export const parseCampaignCauses = campaign => {
+  // These are provided as two separate ordered arrays
+  // from Rogue's Campaigns API. We'll zip them together.
+  const { cause, causeNames } = campaign;
+
+  return zipWith(cause, causeNames, (id, name) => ({ id, name }));
 };

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -61,8 +61,8 @@ const typeDefs = gql`
 
   "A cause space."
   type Cause {
-    id: String!
-    name: String!
+    id: String
+    name: String
   }
 
   "A campaign."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -23,6 +23,7 @@ import {
   toggleReaction,
   getPostsCount,
   makeImpactStatement,
+  parseCampaignCauses,
 } from '../repositories/rogue';
 
 /**
@@ -34,6 +35,8 @@ const typeDefs = gql`
   scalar DateTime
 
   scalar AbsoluteUrl
+
+  directive @requires(fields: String!) on FIELD_DEFINITION
 
   directive @optional on FIELD_DEFINITION
 
@@ -56,6 +59,12 @@ const typeDefs = gql`
     HUMAN_FORMAT
   }
 
+  "A cause space."
+  type Cause {
+    id: String!
+    name: String!
+  }
+
   "A campaign."
   type Campaign {
     "The time when this campaign was originally created."
@@ -68,6 +77,8 @@ const typeDefs = gql`
     internalTitle: String!
     "Collection of Actions associated to the Campaign."
     actions: [Action]
+    "The cause-spaces for this campaign."
+    causes: [Cause] @requires(fields: "cause causeNames")
     "Is this campaign open?"
     isOpen: Boolean!
     "The number of posts pending review. Only visible by staff/admins."
@@ -440,6 +451,7 @@ const resolvers = {
   Campaign: {
     actions: (campaign, args, context) =>
       Loader(context).actionsByCampaignId.load(campaign.id),
+    causes: campaign => parseCampaignCauses(campaign),
   },
 };
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -61,8 +61,8 @@ const typeDefs = gql`
 
   "A cause space."
   type Cause {
-    id: String
-    name: String
+    id: String!
+    name: String!
   }
 
   "A campaign."


### PR DESCRIPTION
This pull request adds a `Cause` type and uses it to expose causes for each campaign.

I decided to "zip" together the machine-friendly `cause` and human-friendly `causeNames` fields from Rogue's Campaign API together so that we don't have to add logic client-side to pair them.

<img width="1392" alt="Screen Shot 2019-11-01 at 1 54 40 PM" src="https://user-images.githubusercontent.com/583202/68045193-55c59800-fcaf-11e9-81c5-21ffc815a782.png">
