### PR TITLE
Add `Post.campaign`, `reviewPost`, and `tagPost`.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -293,6 +293,23 @@ export const toggleReaction = async (postId, context) => {
 };
 
 /**
+ * Create a review for a post.
+ *
+ * @param {Number} postId
+ * @param {String} status
+ * @return {Object}
+ */
+export const reviewPost = async (postId, status, context) => {
+  const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/reviews`, {
+    method: 'POST',
+    body: JSON.stringify({ status: status.toLowerCase() }),
+    ...requireAuthorizedRequest(context),
+  });
+
+  return transformItem(await response.json());
+};
+
+/**
  * Get Rogue signup permalink by ID.
  *
  * @param {Number} id

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -310,6 +310,23 @@ export const reviewPost = async (postId, status, context) => {
 };
 
 /**
+ * Add or remove a tag to a post.
+ *
+ * @param {Number} postId
+ * @param {String} tag
+ * @return {Object}
+ */
+export const tagPost = async (postId, tag, context) => {
+  const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/tags`, {
+    method: 'POST',
+    body: JSON.stringify({ tag_name: tag.toLowerCase() }),
+    ...requireAuthorizedRequest(context),
+  });
+
+  return transformItem(await response.json());
+};
+
+/**
  * Get Rogue signup permalink by ID.
  *
  * @param {Number} id

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -24,6 +24,7 @@ import {
   getPostsCount,
   makeImpactStatement,
   parseCampaignCauses,
+  reviewPost,
 } from '../repositories/rogue';
 
 /**
@@ -383,6 +384,13 @@ const typeDefs = gql`
       "The post ID to react to."
       postId: Int!
     ): Post
+    "Review a post. Requires staff/admin role."
+    reviewPost(
+      "The post ID to review."
+      id: Int!
+      "The status to give this post."
+      status: ReviewStatus!
+    ): Post
   }
 `;
 
@@ -451,6 +459,7 @@ const resolvers = {
   },
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),
+    reviewPost: (_, args, context) => reviewPost(args.id, args.status, context),
   },
   Campaign: {
     actions: (campaign, args, context) =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -164,6 +164,8 @@ const typeDefs = gql`
     userId: String
     "The Rogue campaign ID this post was made for."
     campaignId: String
+    "The Rogue campaign this post was made for."
+    campaign: Campaign
     "The location this post was submitted from. This is provided by Fastly geo-location headers on the web."
     location(format: LocationFormat = ISO_FORMAT): String
     "The attached media for this post."
@@ -396,6 +398,8 @@ const resolvers = {
     url: (media, args) => urlWithQuery(media.url, args),
   },
   Post: {
+    campaign: (post, args, context, info) =>
+      Loader(context).campaigns.load(post.campaignId, getFields(info)),
     signup: (post, args, context) =>
       Loader(context).signups.load(post.signupId),
     url: (post, args) => urlWithQuery(post.media.url, args),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -25,6 +25,7 @@ import {
   makeImpactStatement,
   parseCampaignCauses,
   reviewPost,
+  tagPost,
 } from '../repositories/rogue';
 
 /**
@@ -391,6 +392,13 @@ const typeDefs = gql`
       "The status to give this post."
       status: ReviewStatus!
     ): Post
+    "Add or remove a tag on a post. Requires staff/admin role."
+    tagPost(
+      "The post ID to review."
+      id: Int!
+      "The tag to add or remove on this post."
+      tag: String!
+    ): Post
   }
 `;
 
@@ -460,6 +468,7 @@ const resolvers = {
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),
     reviewPost: (_, args, context) => reviewPost(args.id, args.status, context),
+    tagPost: (_, args, context) => tagPost(args.id, args.tag, context),
   },
   Campaign: {
     actions: (campaign, args, context) =>


### PR DESCRIPTION
This pull request adds some features for displaying & reviewing posts in Rogue:

🍡 Adds a `campaign: Campaign` field to the `Post` type. bd83d3f

👁‍🗨 Adds a `reviewPost` mutation to review a given post. 5cc884d

🏷 Adds a `tagPost` mutation to add/remove tags on a given post. afac6af

References [#169512736](https://www.pivotaltracker.com/story/show/169512736).