### PR TITLE
Fix Content Type Mapping - Phoenix Contentful Campaigns

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -403,7 +403,7 @@ const typeDefs = gql`
  */
 const contentTypeMappings = {
   affiliates: 'AffiliateBlock',
-  campaignWebsite: 'CampaignWebsite',
+  campaign: 'CampaignWebsite',
   page: 'Page',
   embed: 'EmbedBlock',
   contentBlock: 'ContentBlock',


### PR DESCRIPTION
This PR fixes the content type mapping (between our in house GraphQL types and the Contentful Content types) for the `campaign` content type.

I accidentally set it as such way back in #112, but we never encountered issues since we query for this entity directly via the [`campaignWebsiteByCampaignId`](https://github.com/DoSomething/graphql/blob/591fdef533bedb0026da032f55dbc5b1f6197e11/src/schema/contentful/phoenix.js#L394) query and thus never need to resolve the type! 

I encountered this issue when starting to set up some Showcasable queries -- where we [_do_ resolve the type](https://github.com/DoSomething/graphql/blob/591fdef533bedb0026da032f55dbc5b1f6197e11/src/schema/contentful/phoenix.js#L454-L457) -- over on Phoenix, with the `CampaignWebsite` using the Showcaseable interface, resulting in a `"Did not fetch typename for object, unable to resolve interface."` error.

e.g.
![image](https://user-images.githubusercontent.com/12417657/68164061-e4dde480-ff29-11e9-924e-873bf041da5a.png)


[Pivotal ID #168182024](https://www.pivotaltracker.com/story/show/168182024)