### PR TITLE
Phoenix Contentful Schema updates

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -175,7 +175,7 @@ const typeDefs = gql`
     "The list of Action IDs to show in this gallery."
     actionIds: [Int]!
     "The maximum number of items in a single row when viewing the gallery in a large display."
-    itemsPerRow: Int
+    itemsPerRow: Int!
     "A filter type which users can select to filter the gallery."
     filterType: String
     "Hide the post reactions for this gallery."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -129,6 +129,7 @@ const typeDefs = gql`
     title: String!
     description: JSON!
     content: JSON!
+    ${entryFields}
   }
 
   type ImagesBlock implements Block {

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -146,6 +146,10 @@ const typeDefs = gql`
     active: Boolean!
     "Job title of the person."
     jobTitle: String
+    "The perons's email address."
+    email: String
+    "The person's Twitter handle."
+    twitterId: String
     "Photo of the person."
     photo: Asset
     "Alternate Photo of the person."


### PR DESCRIPTION
This PR adds a few simple updates to our Phoenix Contentful schema:
- https://github.com/DoSomething/graphql/commit/2954cb21c796081519f679658351c1a21e089d10 makes the `itemsPerRow` field required for `PostGalleryBlocks` since it's required on the [Contentful entity](https://git.io/Je2jp) and this avoids the collisions with the `GalleryBlock`s [`itemsPerRow`](https://github.com/DoSomething/graphql/blob/c46c4e463597b22ac0e351361ed16f4a1dc2de72/src/schema/contentful/phoenix.js#L192) which was [discussed here](https://dosomething.slack.com/archives/CAPHYCR8V/p1566249170003800)
- https://github.com/DoSomething/graphql/commit/6183f6c3597e44eb5b90ec249a24508612d0b549 adds a few missing PersonBlock fields, which we'll need for `GalleryBlock` querying on Phoenix
- https://github.com/DoSomething/graphql/commit/25952a7621fdbeb7f5a825920242e303cd15d040 adds the standard `entryFields` to the `CausePage` which I mistakenly omitted in #146 