### PR TITLE
Add 'updatePostQuantity', 'rotatePost', and 'deletePost' mutations.

### DIFF
--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -66,6 +66,10 @@ export const transformResponse = (data, idField = 'id') => {
     delete result.northstarId;
   }
 
+  // Add a "deleted" field. Since this response didn't
+  // 404, we can assume it hasn't been deleted:
+  result.deleted = false;
+
   return result;
 };
 

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -344,6 +344,23 @@ export const tagPost = async (postId, tag, context) => {
 };
 
 /**
+ * Rotate a post's image.
+ *
+ * @param {Number} postId
+ * @param {Number} degrees
+ * @return {Object}
+ */
+export const rotatePost = async (postId, degrees, context) => {
+  const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/rotate`, {
+    method: 'POST',
+    body: JSON.stringify({ degrees }),
+    ...requireAuthorizedRequest(context),
+  });
+
+  return transformItem(await response.json());
+};
+
+/**
  * Get Rogue signup permalink by ID.
  *
  * @param {Number} id

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -301,7 +301,7 @@ export const toggleReaction = async (postId, context) => {
  */
 export const updatePostQuantity = async (postId, quantity, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
-    method: 'PUT',
+    method: 'PATCH',
     body: JSON.stringify({ quantity }),
     ...requireAuthorizedRequest(context),
   });

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -361,6 +361,25 @@ export const rotatePost = async (postId, degrees, context) => {
 };
 
 /**
+ * Delete a post.
+ *
+ * @param {Number} postId
+ * @return {Object}
+ */
+export const deletePost = async (postId, context) => {
+  const post = await getPostById(postId, context);
+
+  const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
+    method: 'DELETE',
+    ...requireAuthorizedRequest(context),
+  });
+
+  return response.status === 200
+    ? { ...post, deleted: true }
+    : { ...post, deleted: false };
+};
+
+/**
  * Get Rogue signup permalink by ID.
  *
  * @param {Number} id

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -293,6 +293,23 @@ export const toggleReaction = async (postId, context) => {
 };
 
 /**
+ * Update a post's quantity.
+ *
+ * @param {Number} postId
+ * @param {Number} quantity
+ * @return {Object}
+ */
+export const updatePostQuantity = async (postId, quantity, context) => {
+  const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
+    method: 'PUT',
+    body: JSON.stringify({ quantity }),
+    ...requireAuthorizedRequest(context),
+  });
+
+  return transformItem(await response.json());
+};
+
+/**
  * Create a review for a post.
  *
  * @param {Number} postId

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -24,6 +24,7 @@ import {
   getPostsCount,
   makeImpactStatement,
   parseCampaignCauses,
+  updatePostQuantity,
   reviewPost,
   tagPost,
 } from '../repositories/rogue';
@@ -385,6 +386,13 @@ const typeDefs = gql`
       "The post ID to react to."
       postId: Int!
     ): Post
+    "Update quantity on a post. Requires staff/admin role."
+    updatePostQuantity(
+      "The post ID to update."
+      id: Int!
+      "The new quantity."
+      quantity: Int!
+    ): Post
     "Review a post. Requires staff/admin role."
     reviewPost(
       "The post ID to review."
@@ -467,6 +475,8 @@ const resolvers = {
   },
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),
+    updatePostQuantity: (_, args, context) =>
+      updatePostQuantity(args.id, args.quantity, context),
     reviewPost: (_, args, context) => reviewPost(args.id, args.status, context),
     tagPost: (_, args, context) => tagPost(args.id, args.tag, context),
   },

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -27,6 +27,7 @@ import {
   updatePostQuantity,
   reviewPost,
   tagPost,
+  rotatePost,
 } from '../repositories/rogue';
 
 /**
@@ -407,6 +408,13 @@ const typeDefs = gql`
       "The tag to add or remove on this post."
       tag: String!
     ): Post
+    "Rotate a post's image. Requires staff/admin role."
+    rotatePost(
+      "The post ID to rotate."
+      id: Int!
+      "The number of degrees to rotate (clockwise)."
+      degrees: Int! = 90
+    ): Post
   }
 `;
 
@@ -479,6 +487,8 @@ const resolvers = {
       updatePostQuantity(args.id, args.quantity, context),
     reviewPost: (_, args, context) => reviewPost(args.id, args.status, context),
     tagPost: (_, args, context) => tagPost(args.id, args.tag, context),
+    rotatePost: (_, args, context) =>
+      rotatePost(args.id, args.degrees, context),
   },
   Campaign: {
     actions: (campaign, args, context) =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -28,6 +28,7 @@ import {
   reviewPost,
   tagPost,
   rotatePost,
+  deletePost,
 } from '../repositories/rogue';
 
 /**
@@ -210,6 +211,8 @@ const typeDefs = gql`
     createdAt: DateTime
     "Permalink to Admin view."
     permalink: String
+    "This flag is set when a post has been deleted. On subsequent queries, this post will be null."
+    deleted: Boolean
   }
 
   "A user's signup for a campaign."
@@ -415,6 +418,11 @@ const typeDefs = gql`
       "The number of degrees to rotate (clockwise)."
       degrees: Int! = 90
     ): Post
+    "Delete a post. Requires staff/admin role."
+    deletePost(
+      "The post ID to delete."
+      id: Int!
+    ): Post
   }
 `;
 
@@ -489,6 +497,7 @@ const resolvers = {
     tagPost: (_, args, context) => tagPost(args.id, args.tag, context),
     rotatePost: (_, args, context) =>
       rotatePost(args.id, args.degrees, context),
+    deletePost: (_, args, context) => deletePost(args.id, context),
   },
   Campaign: {
     actions: (campaign, args, context) =>


### PR DESCRIPTION
This pull request adds the final batch of mutations that Rogue's admin panel relies on:

🔢 Adds 'updatePostQuantity' to edit the quantity on a post. 604aea0 & c930d0d

🔄 Adds `rotatePost` to rotate a photo (via DoSomething/rogue#933). 154bf0c

🗑 Adds `deletePost` mutation, and a `deleted` field which lets us update existing posts in the interface to show that they've been deleted. For reference, here's a [discussion](https://git.io/Jea8R) on various approaches (and lack of a good built-in construct) for deleting things in Apollo. e3dd91d