### PR TITLE
Adds user.school

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -23,6 +23,8 @@ const linkSchema = gql`
     signups: [Signup]
     "The conversations created by this user."
     conversations: [Conversation]
+    "The user's current school. Note -- only works if user.schoolId is also returned"
+    school: School
   }
 
   extend type Post {
@@ -231,6 +233,25 @@ const linkResolvers = {
           context,
           info,
         );
+      },
+    },
+    school: {
+      fragment: 'fragment SchoolFragment on User { id }',
+      resolve(user, args, context, info) {
+        if (!user.schoolId) {
+          return null;
+        }
+
+        return info.mergeInfo.delegateToSchema({
+          schema: schoolsSchema,
+          operation: 'query',
+          fieldName: 'school',
+          args: {
+            id: user.schoolId,
+          },
+          context,
+          info,
+        });
       },
     },
   },


### PR DESCRIPTION
Supports a `school(:id)` query (#152) per a user's `schoolId` (#149 ). I'm not sure if there's a workaround for needing to include `schoolId` in a query to get the `school` to work, as I notice in the logs that the `?include=school_id` seems to be necessary per https://github.com/DoSomething/northstar/pull/956

Example query: 
```
{
user(id:"5daa307dfdce2713286465c3") {
  firstName
  schoolId
  school {
    id
    name
    city
    state
  }
}}
```
Example response:
```
{
  "data": {
    "user": {
      "firstName": "Puppet",
      "schoolId": "12500012",
      "school": {
        "id": "12500012",
        "name": "Southwick-Tolland-Granville Regional School District",
        "city": "Southwick",
        "state": "MA"
      }
    }
  },
  ...
```