### PR TITLE
Support school-not-available id with user.school

### DIFF
--- a/src/repositories/schools.js
+++ b/src/repositories/schools.js
@@ -3,6 +3,8 @@ import { MongoClient } from 'mongodb';
 
 import config from '../../config';
 
+const SCHOOL_NOT_AVAILABLE_SCHOOL_ID = 'school-not-available';
+
 /**
  * Schools are sourced from a Mongo database, in a collection called 'directory'.
  * We use the following fields to source our list of schools.
@@ -63,6 +65,12 @@ export const transformItem = item => {
  * @return {Object}
  */
 export const getSchoolById = async id => {
+  if (id === SCHOOL_NOT_AVAILABLE_SCHOOL_ID) {
+    return {
+      id: SCHOOL_NOT_AVAILABLE_SCHOOL_ID,
+    };
+  }
+
   logger.debug('Finding school', { id });
 
   const db = await connectToDatabase();

--- a/src/schema/schools.js
+++ b/src/schema/schools.js
@@ -14,11 +14,11 @@ const typeDefs = gql`
     "The school ID."
     id: String!
     "The school name."
-    name: String!
+    name: String
     "The school city."
-    city: String!
+    city: String
     "The school state."
-    state: String!
+    state: String
   }
 
   type Query {


### PR DESCRIPTION
If a user can't find their school in the School Finder, we want to save the value `school-not-available` to their `school_id` field, so when they revisit the campaign later, a "School not selected" view is displayed. 

If a user has `school-not-available` set, querying by the `user.school` property (as we're [currently doing over in Phoenix](https://github.com/DoSomething/phoenix-next/blob/94c30d5bff3dbd57a96e758c2c9a5f92458b9a95/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js#L15)) will result in a GraphQL error: `Cannot destructure property `name` of 'undefined' or 'null'."`
```
{
user(id:"5daa307dfdce2713286465c3") {
  firstName
  schoolId
  school {
    id
    name
    city
    state
  }
}}
```

This PR checks for the `school-not-availalble` value within the `getSchoolById` function, and returns an object with just an `id` value to avoid the error:

Example result:
```
{
  "data": {
    "user": {
      "firstName": "Julian",
      "schoolId": "school-not-available",
      "school": {
        "id": "school-not-available",
        "name": null,
        "city": null,
        "state": null
      }
    }
  },
  ...
```