### PR TITLE
Add 'acceptedCount' to Campaign.

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -90,7 +90,9 @@ const typeDefs = gql`
     "Is this campaign open?"
     isOpen: Boolean!
     "The number of posts pending review. Only visible by staff/admins."
-    pendingCount: Int @optional
+    pendingCount: Int
+    "The number of accepted posts."
+    acceptedCount: Int
     "The time when this campaign starts."
     startDate: DateTime
     "The time when this campaign last modified."


### PR DESCRIPTION
This pull request adds `acceptedCount` to `Campaign` (added in DoSomething/rogue#947), and removes the `@optional` directive on `pendingCount` since we no longer need to use the `?include=pending_count` query string to include it in the response.