### PR TITLE
Adds Post.collectSchoolId

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -131,6 +131,8 @@ const typeDefs = gql`
     civicAction: Boolean
     "Does this action count as a scholarship entry?"
     scholarshipEntry: Boolean
+    "Does this action associate user posts with their school?"
+    collectSchoolId: Boolean
     "Anonymous actions will not be attributed to a particular user in public galleries."
     anonymous: Boolean
     "The noun for this action, e.g. 'cards' or 'jeans'."


### PR DESCRIPTION
Adds support for https://github.com/DoSomething/rogue/pull/954.

Example request: 
```
{
  action(id: 2) {
    name
    collectSchoolId
  }
}

```
Example response:
```
{
  "data": {
    "action": {
      "name": "Teens For Jeans Photo Upload",
      "collectSchoolId": true
    }
  },
  ...
```