### PR TITLE
Cache Preview API calls & clean up.

### DIFF
--- a/config/embed.js
+++ b/config/embed.js
@@ -1,15 +1,5 @@
 export default {
   /**
-   * Catbox cache settings for embeds.
-   *
-   * @type {Object}
-   */
-  cache: {
-    name: 'embed',
-    expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
-  },
-
-  /**
    * We whitelist "safe" domains to embed rich content from, to prevent
    * malicious HTML content from being injected onto a page.
    *

--- a/config/services.js
+++ b/config/services.js
@@ -10,13 +10,6 @@ const environmentMapping = {
 };
 
 const contentful = {
-  // Global Contentful cache. This should be used for any spaces
-  // that have a webhook enabled for cache clearing.
-  cache: {
-    name: 'contentful',
-    expiresIn: 24 * 3600 * 1000, // 24 hours (3600 seconds per hour).
-  },
-
   phoenix: {
     spaceId: process.env.PHOENIX_CONTENTFUL_SPACE_ID,
     accessToken: process.env.PHOENIX_CONTENTFUL_ACCESS_TOKEN,

--- a/config/services.js
+++ b/config/services.js
@@ -22,20 +22,12 @@ const contentful = {
     accessToken: process.env.PHOENIX_CONTENTFUL_ACCESS_TOKEN,
     previewToken: process.env.PHOENIX_CONTENTFUL_PREVIEW_TOKEN,
     environment: get(environmentMapping, process.env.QUERY_ENV),
-    cache: {
-      name: 'phoenixContent',
-      expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
-    },
   },
 
   // Gambit uses a single space/environment used across all GraphQL environments.
   gambit: {
     spaceId: process.env.GAMBIT_CONTENTFUL_SPACE_ID,
     accessToken: process.env.GAMBIT_CONTENTFUL_ACCESS_TOKEN,
-    cache: {
-      name: 'gambitContent',
-      expiresIn: 3600 * 1000, // 1 hour (3600 seconds).
-    },
   },
 };
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -6,6 +6,10 @@ import logger from 'heroku-logger';
 
 import config from '../config';
 
+// Some common expiration values:
+export const ONE_HOUR = 3600 * 1000;
+export const ONE_MONTH = 31 * 24 * 3600 * 1000;
+
 /**
  * Get the cache driver.
  *
@@ -30,7 +34,7 @@ const getClient = driver => {
 };
 
 export default class {
-  constructor({ name, expiresIn }) {
+  constructor(name, expiresIn = ONE_MONTH) {
     this.name = name;
     this.client = getClient(config('cache.driver'));
     this.policy = new Policy({ expiresIn }, this.client, 'segment');

--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -8,7 +8,7 @@ import Loader from '../../loader';
 
 // const inspect = require('util').inspect;
 
-const cache = new Cache(config('services.contentful.cache'));
+const cache = new Cache('contentful');
 const spaceId = config('services.contentful.gambit.spaceId');
 
 const contentfulClient = createClient({

--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -3,12 +3,11 @@ import { assign, map } from 'lodash';
 import logger from 'heroku-logger';
 
 import config from '../../../config';
-import Cache from '../../cache';
 import Loader from '../../loader';
+import Cache, { ONE_MONTH } from '../../cache';
 
-// const inspect = require('util').inspect;
+const cache = new Cache('contentful', ONE_MONTH);
 
-const cache = new Cache('contentful');
 const spaceId = config('services.contentful.gambit.spaceId');
 
 const contentfulClient = createClient({

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -7,7 +7,7 @@ import config from '../../../config';
 import Loader from '../../loader';
 import Cache from '../../cache';
 
-const cache = new Cache(config('services.contentful.cache'));
+const cache = new Cache('contentful');
 const spaceId = config('services.contentful.phoenix.spaceId');
 
 const contentfulSpaceConfig = {

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -4,12 +4,14 @@ import logger from 'heroku-logger';
 import { createWindow } from 'domino';
 import { getMetadata } from 'page-metadata-parser';
 
-import Cache from '../cache';
 import config from '../../config';
+import Cache, { ONE_HOUR } from '../cache';
 import { transformResponse } from './helpers';
 
 const embedClient = OEmbetter();
-const cache = new Cache(config('embed.cache'));
+
+// Configure embed cache (for one hour).
+const cache = new Cache('embed', ONE_HOUR);
 
 // Configure custom endpoint mappings. <https://git.io/fjeXT>
 embedClient.endpoints(embedClient.suggestedEndpoints);

--- a/webhook.js
+++ b/webhook.js
@@ -37,6 +37,7 @@ exports.handler = async event => {
 
   // Clear cache for the specified entry from the Contentful cache.
   const cache = new Cache('contentful');
+  const previewCache = new Cache('preview.contentful');
 
   const id = body.sys.id;
   const type = body.sys.type;
@@ -44,7 +45,10 @@ exports.handler = async event => {
   const contentType = body.sys.contentType && body.sys.contentType.sys.id;
 
   // Clear from DynamoDB (and await to make sure this completes).
+  // @TODO: We should clear production cache on 'publish' events, and
+  // preview cache on 'save' events (rather than always clearing both).
   await cache.forget(`${type}:${spaceId}:${id}`);
+  await previewCache.forget(`${type}:${spaceId}:${id}`);
 
   logger.info('Cleared cache via Contentful webhook.', { spaceId, id });
 
@@ -67,7 +71,10 @@ exports.handler = async event => {
 
       if (fieldValue) {
         // Clear from DynamoDB (and await to make sure this completes).
+        // @TODO: We should clear production cache on 'publish' events, and
+        // preview cache on 'save' events (rather than always clearing both).
         await cache.forget(`${contentType}:${spaceId}:${fieldValue}`);
+        await previewCache.forget(`${contentType}:${spaceId}:${fieldValue}`);
 
         logger.info(`Cleared ${contentType} cache via Contentful webhook`, {
           spaceId,

--- a/webhook.js
+++ b/webhook.js
@@ -36,7 +36,7 @@ exports.handler = async event => {
   }
 
   // Clear cache for the specified entry from the Contentful cache.
-  const cache = new Cache(config('services.contentful.cache'));
+  const cache = new Cache('contentful');
 
   const id = body.sys.id;
   const type = body.sys.type;
@@ -75,7 +75,7 @@ exports.handler = async event => {
           [cacheKey]: fieldValue,
         });
       }
-    };
+    }
   }
 
   return response('Success.', 200);


### PR DESCRIPTION
This pull request increases our Contentful cache TTL (from 24 hours to 31 days) and begins caching Preview API calls to address issues we'd seen with aggressive rate-limiting there. I've also refactored the `Cache` constructor to be simpler (since we don't customize cache or TTL by environment variables or per environment).

References [#169871166](https://www.pivotaltracker.com/story/show/169871166).