### PR TITLE
Add the hidePageViews field to the social share drive block

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -444,6 +444,8 @@ const typeDefs = gql`
     internalTitle: String!
     "The link for this social drive, with dynamic string tokens."
     link: AbsoluteUrl
+    "Toggles the display of the page views info card adjacent to the block"
+    hidePageViews: Boolean
     ${entryFields}
   }
 


### PR DESCRIPTION
This PR adds the `hidePageViews` field to the `SocialDriveBlock` schema as per the update to the action in https://github.com/DoSomething/phoenix-next/pull/1748