### PR TITLE
Fix link resolver for author.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -640,7 +640,8 @@ const resolvers = {
       Loader(context, preview).pages.load(id),
   },
   AffirmationBlock: {
-    author: linkResolver,
+    author: (person, _, context, info) =>
+      linkResolver(person, _, context, info, 'newAuthor'),
   },
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),


### PR DESCRIPTION
It turns out this field is named `newAuthor`, so the default link resolver wasn't able to resolve it! This pull request updates it to specify the real field name, as we do with some other fields that have different names in Contentful and GraphQL.