### PR TITLE
Two fixes for new GraphQL block types.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -423,7 +423,7 @@ const typeDefs = gql`
     "This title is used internally to help find this content."
     internalTitle: String!
     "The Rogue action ID for this submission block."
-    actionId: Int!
+    actionId: Int
     "The user-facing title for this share block."
     title: String
     "The content, in Rich Text."
@@ -457,7 +457,7 @@ const typeDefs = gql`
     "The user-facing title for this block."
     title: String
     "The Rogue action ID for this submission block."
-    actionId: Int!
+    actionId: Int
     "The SoftEdge campaign ID for this submission block."
     softEdgeId: Int!
     ${entryFields}

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -428,6 +428,8 @@ const typeDefs = gql`
     title: String
     "The content, in Rich Text."
     content: JSON!
+    "The content, in Rich Text. This is an alias for 'content'."
+    richText: JSON!
     "The label displayed above the selection field."
     selectionFieldLabel: String
     "The selection options for the selection block."
@@ -690,6 +692,9 @@ const resolvers = {
   },
   PetitionSubmissionBlock: {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
+  },
+  SelectionSubmissionBlock: {
+    richText: block => block.content,
   },
   ShareBlock: {
     affirmationBlock: linkResolver,


### PR DESCRIPTION
This pull request makes two fixes for type conflicts I ran into when querying these new types via `ContentfulEntryLoader` in Phoenix. Because these are loaded into the same query via fragments, fields with the same name need to share the same return type. To ensure this:

🔢 I swapped `actionId` to be `Int` across the board (since in some cases, we still have content where this is null). Once this is set on all our content, we can swap these all to `Int!`. c6fdc9a

🤑 Adds a `richText` alias for `content` on SelectionSubmissionBlock, so we don't conflict with `content: String` on other blocks. I chose to do this on the server (instead of a client-side alias) since it we'll eventually want to [migrate existing `content: String` to rich-text this way](https://www.pivotaltracker.com/story/show/169959187).