### PR TITLE
Add 'SixpackExperimentBlock' to Phoenix schema.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -419,6 +419,28 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  "Types of events that can count as conversions for Sixpack Experiment blocks."
+  enum SixpackConversionEvent {
+    SIGNUP
+    REPORTBACK_POST
+  }
+
+  type SixpackExperimentBlock implements Block {
+    "This title is used internally to help find this content."
+    internalTitle: String!
+    "This (optional) block should be used as the control in the experiment."
+    control: Block
+    "The test alternatives for this experiment."
+    alternatives: [Block]!
+    "The actions that will count as a conversion for this experiment."
+    convertableActions: [SixpackConversionEvent]
+    "The percent of traffic to run the experiment on, from 1 - 100."
+    trafficFraction: Int
+    "The KPI to associate with this experiment."
+    kpi: String
+    ${entryFields}
+  }
+
   type SelectionSubmissionBlock implements Block {
     "This title is used internally to help find this content."
     internalTitle: String!
@@ -607,6 +629,7 @@ const contentTypeMappings = {
   quiz: 'QuizBlock',
   sectionBlock: 'SectionBlock',
   selectionSubmissionAction: 'SelectionSubmissionBlock',
+  sixpackExperiment: 'SixpackExperimentBlock',
   socialDriveAction: 'SocialDriveBlock',
   shareAction: 'ShareBlock',
   softEdgeWidgetAction: 'SoftEdgeBlock',

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -716,6 +716,9 @@ const resolvers = {
   PetitionSubmissionBlock: {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
   },
+  SixpackExperimentBlock: {
+    convertableActions: block => listToEnums(block.convertableActions),
+  },
   SelectionSubmissionBlock: {
     richText: block => block.content,
   },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -717,6 +717,8 @@ const resolvers = {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
   },
   SixpackExperimentBlock: {
+    control: linkResolver,
+    alernatives: linkResolver,
     convertableActions: block => listToEnums(block.convertableActions),
   },
   SelectionSubmissionBlock: {

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -718,7 +718,7 @@ const resolvers = {
   },
   SixpackExperimentBlock: {
     control: linkResolver,
-    alernatives: linkResolver,
+    alternatives: linkResolver,
     convertableActions: block => listToEnums(block.convertableActions),
   },
   SelectionSubmissionBlock: {

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,3 +1,5 @@
+import { snakeCase } from 'lodash';
+
 /**
  * Transform a string constant into a GraphQL-style enum.
  *
@@ -9,7 +11,7 @@ export const stringToEnum = string => {
     return null;
   }
 
-  return string.toUpperCase().replace('-', '_');
+  return snakeCase(string).toUpperCase();
 };
 
 /**


### PR DESCRIPTION
This just adds the `SixpackExperimentBlock` to our Phoenix schema, for [this content type](https://app.contentful.com/spaces/81iqaqpfd8fy/content_types/sixpackExperiment/fields). As part of this work, I refactored `stringToEnum` to handle more input types (e.g. turning `reportbackPost` from this Contentful type into the expected `REPORTBACK_POST` for the enum).

![Screen Shot 2019-11-26 at 12 03 00 PM](https://user-images.githubusercontent.com/583202/69655524-b5138f80-1044-11ea-8c2e-521001b36e27.png)
