### PR TITLE
Adds campaign property to Action

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -127,6 +127,8 @@ const typeDefs = gql`
     reportback: Boolean
     "Campaign ID this action belongs to"
     campaignId: Int!
+    "Campaign this action belongs to"
+    campaign: Campaign
     "Does this action count as a civic action?"
     civicAction: Boolean
     "Does this action count as a scholarship entry?"
@@ -485,6 +487,10 @@ const typeDefs = gql`
 const resolvers = {
   DateTime: GraphQLDateTime,
   AbsoluteUrl: GraphQLAbsoluteUrl,
+  Action: {
+    campaign: (action, args, context, info) =>
+      Loader(context).campaigns.load(action.campaignId, getFields(info)),
+  },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
   },


### PR DESCRIPTION
Looking for this when adding an action permalink over in https://github.com/DoSomething/rogue/pull/959.

Example request:
```
{
  action(id: 24) {
    name
    campaign {
      id
      internalTitle
      startDate
    }
  }
}

```

Example response:
```
{
  "data": {
    "action": {
      "name": "Anxiety Textline Social Share",
      "campaign": {
        "id": 9001,
        "internalTitle": "Public-Key Non-Volatile Budgetarymanagement",
        "startDate": "2019-08-29T23:34:58Z"
      }
    }
  },
  ...
```
