### PR TITLE
Add 'CampaignDashboard' to schema.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -138,6 +138,24 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type CampaignDashboard implements Block {
+    "This title is used internally to help find this content."
+    internalTitle: String!
+    "Heading for the share section of the dashboard."
+    shareHeader: String
+    "Copy for the share section of the dashboard."
+    shareCopy: String
+    "The first dashboard value presented, likely a number."
+    firstValue: String
+    "A short description of the first value."
+    firstDescription: String
+    "The second dashboard value presented, likely a number."
+    secondValue: String
+    "A short description of the second value."
+    secondDescription: String
+    ${entryFields}
+  }
+
   type CampaignUpdateBlock implements Block {
     "This title is used internally to help find this content."
     internalTitle: String!
@@ -618,6 +636,7 @@ const contentTypeMappings = {
   affiliates: 'AffiliateBlock',
   campaign: 'CampaignWebsite',
   callToAction: 'CallToActionBlock',
+  campaignDashboard: 'CampaignDashboard',
   campaignUpdate: 'CampaignUpdateBlock',
   page: 'Page',
   embed: 'EmbedBlock',


### PR DESCRIPTION
### What's this PR do?

This pull request adds `CampaignDashboard` to our GraphQL schema.

Here's an example from QA that I queried:

![Screen Shot 2019-12-03 at 12 03 26 PM](https://user-images.githubusercontent.com/583202/70072420-f49e2680-15c4-11ea-9827-f2651199d238.png)


### How should this be reviewed?

Does the schema & field documentation look reasonable? Here's the [content type](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/qa/content_types/campaignDashboard/fields).

### Any background context you want to provide?

This is the one (oy) thing that we have actually run an A/B test for, so adding support for querying this content type is a pre-requisite for allowing `SixpackExperiment` to load via GraphQL in Phoenix.

### Relevant tickets

References [Pivotal #170053882](https://www.pivotaltracker.com/story/show/170053882).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
