### PR TITLE
Cause Page schema update

### DIFF
--- a/config/cache.js
+++ b/config/cache.js
@@ -1,10 +1,10 @@
 export default {
   /**
-   * The cache driver. Either 'redis' or 'dynamodb'.
+   * The cache driver. Either 'dynamodb', 'redis', or 'memory'.
    *
    * @type {String}
    */
-  driver: process.env.CACHE_DRIVER || 'redis',
+  driver: process.env.CACHE_DRIVER || 'memory',
 
   /**
    * The Redis server URL, for example

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -215,6 +215,8 @@ const typeDefs = gql`
     description: JSON!
     "The content, in Rich Text."
     content: JSON!
+    "Any custom overrides for this cause page."
+    additionalContent: JSON
     ${entryFields}
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `additionalContent` field to the Cause Page Contentful Phoenix schema

Also updates the default cache driver re https://dosomething.slack.com/archives/CAPHYCR8V/p1575489412004100?thread_ts=1575488758.002300&cid=CAPHYCR8V

### How should this be reviewed?
👁 

### Any background context you want to provide?
https://github.com/DoSomething/phoenix-next/pull/1788

### Relevant tickets

References [Pivotal #169769114](https://www.pivotaltracker.com/story/show/169769114).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
