### PR TITLE
Return null when school not found

### DIFF
--- a/src/repositories/schools.js
+++ b/src/repositories/schools.js
@@ -48,6 +48,10 @@ function connectToDatabase() {
  * @return {Object}
  */
 export const transformItem = item => {
+  if (!item) {
+    return null;
+  }
+
   const { name, city, state } = item;
 
   return {


### PR DESCRIPTION
### What's this PR do?

This pull request returns `null` if we can't find a school by ID, instead of the `errors` array, keeping consistent with other getTypeById queries.

### How should this be reviewed?

Example request:
```
{
  school(id: "NJ") {
    id
    name
    city
    state
  }
}

```

Example response:
```
{
  "data": {
    "school": null
  },
  ...
```


### Relevant tickets

References https://www.pivotaltracker.com/story/show/169549268

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
