### PR TITLE
Adds SchoolActionStats

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -67,12 +67,7 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * @param {String} orderBy
  * @return {Array}
  */
-export const getActionStats = async (
-  schoolId,
-  actionId,
-  orderBy,
-  context,
-) => {
+export const getActionStats = async (schoolId, actionId, orderBy, context) => {
   logger.debug('Loading action-stats from Rogue', {
     schoolId,
     actionId,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -43,7 +43,6 @@ export const getActionById = async (id, context) => {
  * @param {Number} campaign_id
  * @return {Array}
  */
-
 export const getActionsByCampaignId = async (campaignId, context) => {
   logger.debug('Loading actions from Rogue', {
     campaignId,
@@ -55,6 +54,46 @@ export const getActionsByCampaignId = async (campaignId, context) => {
   );
 
   const json = await response.json();
+
+  return transformCollection(json);
+};
+
+/**
+ * Get a simple list of action stats.
+ *
+ * @param {Number} action_id
+ * @param {String} school_id
+ * @return {Array}
+ */
+export const getActionStats = async (args, context) => {
+  const { actionId, schoolId } = args;
+
+  logger.debug('Loading action-stats from Rogue', {
+    actionId, schoolId,
+  });
+
+  const filter = {};
+
+  if (actionId) {
+    filter.action_id = actionId;
+  }
+  if (schoolId) {
+    filter.school_id = schoolId;
+  }
+
+  const queryString = stringify({
+    filter,
+    orderBy: args.orderBy,
+    pagination: 'cursor',
+  });
+
+  const response = await fetch(
+    `${ROGUE_URL}/api/v3/action-stats/?${queryString}`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
+  console.log(json);
 
   return transformCollection(json);
 };

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -69,7 +69,8 @@ export const getActionStats = async (args, context) => {
   const { actionId, schoolId } = args;
 
   logger.debug('Loading action-stats from Rogue', {
-    actionId, schoolId,
+    actionId,
+    schoolId,
   });
 
   const filter = {};

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -65,7 +65,7 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * @param {Number} action_id
  * @return {Array}
  */
-export const getActionStats = async (
+export const getActionStatsBySchoolIdAndActionId = async (
   schoolId,
   actionId,
   orderBy = 'accepted_quantity,desc',

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -65,7 +65,12 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * @param {Number} action_id
  * @return {Array}
  */
-export const getActionStats = async (schoolId, actionId, orderBy = 'accepted_quantity,desc', context) => {
+export const getActionStats = async (
+  schoolId,
+  actionId,
+  orderBy = 'accepted_quantity,desc',
+  context,
+) => {
   logger.debug('Loading action-stats from Rogue', {
     schoolId,
     actionId,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -60,6 +60,7 @@ export const getActionsByCampaignId = async (campaignId, context) => {
 
 /**
  * Get a simple list of action stats by school and or action ID.
+ * @TODO: We'll eventually need to support pagination as more action collect school ID's.
  *
  * @param {String} school_id
  * @param {Number} action_id

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -67,7 +67,7 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * @param {String} orderBy
  * @return {Array}
  */
-export const getActionStatsBySchoolIdAndActionId = async (
+export const getActionStats = async (
   schoolId,
   actionId,
   orderBy,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -63,12 +63,13 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  *
  * @param {String} school_id
  * @param {Number} action_id
+ * @param {String} orderBy
  * @return {Array}
  */
 export const getActionStatsBySchoolIdAndActionId = async (
   schoolId,
   actionId,
-  orderBy = 'accepted_quantity,desc',
+  orderBy,
   context,
 ) => {
   logger.debug('Loading action-stats from Rogue', {

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -93,7 +93,6 @@ export const getActionStats = async (args, context) => {
   );
 
   const json = await response.json();
-  console.log(json);
 
   return transformCollection(json);
 };

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -59,18 +59,16 @@ export const getActionsByCampaignId = async (campaignId, context) => {
 };
 
 /**
- * Get a simple list of action stats.
+ * Get a simple list of action stats by school and or action ID.
  *
- * @param {Number} action_id
  * @param {String} school_id
+ * @param {Number} action_id
  * @return {Array}
  */
-export const getActionStats = async (args, context) => {
-  const { actionId, schoolId } = args;
-
+export const getActionStats = async (schoolId, actionId, orderBy = 'accepted_quantity,desc', context) => {
   logger.debug('Loading action-stats from Rogue', {
-    actionId,
     schoolId,
+    actionId,
   });
 
   const filter = {};
@@ -84,7 +82,7 @@ export const getActionStats = async (args, context) => {
 
   const queryString = stringify({
     filter,
-    orderBy: args.orderBy,
+    orderBy,
     pagination: 'cursor',
   });
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -112,6 +112,11 @@ const linkSchema = gql`
     "The action that this broadcast is associated to."
     action: Action
   }
+
+  extend type School {
+    "Aggregate post information for this school by action."
+    schoolActionStats: [SchoolActionStat]
+  }
 `;
 
 function blockActionResolver(blockTypeName) {
@@ -344,6 +349,23 @@ const linkResolvers = {
           fieldName: 'school',
           args: {
             id: post.schoolId,
+          },
+          context,
+          info,
+        });
+      },
+    },
+  },
+  School: {
+    schoolActionStats: {
+      fragment: 'fragment SchoolActionStatsFragment on School { schoolId }',
+      resolve(school, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: rogueSchema,
+          operation: 'query',
+          fieldName: 'schoolActionStatsBySchoolId',
+          args: {
+            id: school.id,
           },
           context,
           info,

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -118,6 +118,8 @@ const linkSchema = gql`
     schoolActionStats(
       "The action ID to show a school action stat for."
       actionId: Int
+      "How to order the results (e.g. 'accepted_quantity,desc')."
+      orderBy: String = "accepted_quantity,desc"
     ): [SchoolActionStat]
   }
 
@@ -375,6 +377,7 @@ const linkResolvers = {
           args: {
             schoolId: school.id,
             actionId: args.actionId,
+            orderBy: args.orderBy,
           },
           context,
           info,

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -118,8 +118,8 @@ const linkSchema = gql`
     schoolActionStats(
       "The action ID to show a school action stat for."
       actionId: Int
-      "How to order the results (e.g. 'accepted_quantity,desc')."
-      orderBy: String = "accepted_quantity,desc"
+      "How to order the results (e.g. 'id,desc')."
+      orderBy: String = "id,desc"
     ): [SchoolActionStat]
   }
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -117,6 +117,11 @@ const linkSchema = gql`
     "Aggregate post information for this school by action."
     schoolActionStats: [SchoolActionStat]
   }
+
+  extend type SchoolActionStat {
+    "The school that this school action stat is for."
+    school: School
+  }
 `;
 
 function blockActionResolver(blockTypeName) {
@@ -366,6 +371,23 @@ const linkResolvers = {
           fieldName: 'schoolActionStatsBySchoolId',
           args: {
             id: school.id,
+          },
+          context,
+          info,
+        });
+      },
+    },
+  },
+  SchoolActionStat: {
+    school: {
+      fragment: 'fragment SchoolFragment on SchoolActionStat { id }',
+      resolve(schoolActionStat, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: schoolsSchema,
+          operation: 'query',
+          fieldName: 'school',
+          args: {
+            id: schoolActionStat.schoolId,
           },
           context,
           info,

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -115,7 +115,10 @@ const linkSchema = gql`
 
   extend type School {
     "Aggregate post information for this school by action."
-    schoolActionStats: [SchoolActionStat]
+    schoolActionStats(
+      "The action ID to show a school action stat for."
+      actionId: Int
+    ): [SchoolActionStat]
   }
 
   extend type SchoolActionStat {
@@ -368,9 +371,10 @@ const linkResolvers = {
         return info.mergeInfo.delegateToSchema({
           schema: rogueSchema,
           operation: 'query',
-          fieldName: 'schoolActionStatsBySchoolId',
+          fieldName: 'schoolActionStats',
           args: {
-            id: school.id,
+            schoolId: school.id,
+            actionId: args.actionId,
           },
           context,
           info,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -556,6 +556,10 @@ const resolvers = {
     reactions: post => post.reactions.total,
     permalink: post => getPermalinkByPostId(post.id),
   },
+  SchoolActionStat: {
+    action: (schoolActionStat, args, context, info) =>
+      Loader(context).actions.load(schoolActionStat.actionId, getFields(info)),
+  },
   Signup: {
     campaign: (signup, args, context, info) =>
       Loader(context).campaigns.load(signup.campaignId, getFields(info)),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -527,7 +527,8 @@ const resolvers = {
   Action: {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
-    schoolActionStats: (action, args, context) => getActionStats({ actionId: action.id }, context),
+    schoolActionStats: (action, args, context) =>
+      getActionStats({ actionId: action.id }, context),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
@@ -584,7 +585,8 @@ const resolvers = {
       getPostsByCampaignId(args.id, args.page, args.count, context),
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
-    schoolActionStatsBySchoolId: (_, args, context) => getActionStats({ schoolId: args.id }, context),
+    schoolActionStatsBySchoolId: (_, args, context) =>
+      getActionStats({ schoolId: args.id }, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -9,7 +9,7 @@ import { urlWithQuery } from '../repositories/helpers';
 import OptionalFieldDirective from './directives/OptionalFieldDirective';
 import {
   getActionById,
-  getActionStatsBySchoolIdAndActionId,
+  getActionStats,
   getCampaigns,
   getPaginatedCampaigns,
   getPermalinkBySignupId,
@@ -539,7 +539,7 @@ const resolvers = {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
-      getActionStatsBySchoolIdAndActionId(
+      getActionStats(
         args.schoolId,
         action.id,
         args.orderBy,
@@ -602,7 +602,7 @@ const resolvers = {
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
     schoolActionStats: (_, args, context) =>
-      getActionStatsBySchoolIdAndActionId(
+      getActionStats(
         args.schoolId,
         args.actionId,
         args.orderBy,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -168,6 +168,8 @@ const typeDefs = gql`
     schoolActionStats(
       "The school ID to display an action stat for."
       schoolId: String
+      "How to order the results (e.g. 'accepted_quantity,desc')."
+      orderBy: String = "accepted_quantity,desc"
     ): [SchoolActionStat]
   }
 
@@ -422,6 +424,8 @@ const typeDefs = gql`
       schoolId: String
       "The Action ID to filter school action stats by."
       actionId: Int
+      "How to order the results (e.g. 'id,desc')."
+      orderBy: String = "id,desc"
     ): [SchoolActionStat]
     "Get a signup by ID."
     signup(id: Int!): Signup
@@ -535,7 +539,12 @@ const resolvers = {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
-      getActionStatsBySchoolIdAndActionId(args.schoolId, action.id, args.orderBy, context),
+      getActionStatsBySchoolIdAndActionId(
+        args.schoolId,
+        action.id,
+        args.orderBy,
+        context,
+      ),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
@@ -593,7 +602,12 @@ const resolvers = {
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
     schoolActionStats: (_, args, context) =>
-      getActionStatsBySchoolIdAndActionId(args.schoolId, args.actionId, args.orderBy, context),
+      getActionStatsBySchoolIdAndActionId(
+        args.schoolId,
+        args.actionId,
+        args.orderBy,
+        context,
+      ),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -9,7 +9,7 @@ import { urlWithQuery } from '../repositories/helpers';
 import OptionalFieldDirective from './directives/OptionalFieldDirective';
 import {
   getActionById,
-  getActionStats,
+  getActionStatsBySchoolIdAndActionId,
   getCampaigns,
   getPaginatedCampaigns,
   getPermalinkBySignupId,
@@ -535,7 +535,7 @@ const resolvers = {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
-      getActionStats(args.schoolId, action.id, args.orderBy, context),
+      getActionStatsBySchoolIdAndActionId(args.schoolId, action.id, args.orderBy, context),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
@@ -593,7 +593,7 @@ const resolvers = {
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
     schoolActionStats: (_, args, context) =>
-      getActionStats(args.schoolId, args.actionId, args.orderBy, context),
+      getActionStatsBySchoolIdAndActionId(args.schoolId, args.actionId, args.orderBy, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -539,12 +539,7 @@ const resolvers = {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
-      getActionStats(
-        args.schoolId,
-        action.id,
-        args.orderBy,
-        context,
-      ),
+      getActionStats(args.schoolId, action.id, args.orderBy, context),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
@@ -602,12 +597,7 @@ const resolvers = {
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
     schoolActionStats: (_, args, context) =>
-      getActionStats(
-        args.schoolId,
-        args.actionId,
-        args.orderBy,
-        context,
-      ),
+      getActionStats(args.schoolId, args.actionId, args.orderBy, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -165,7 +165,10 @@ const typeDefs = gql`
     "How long will this action take to complete?"
     timeCommitmentLabel: String
     "Aggregate post information for this action by school."
-    schoolActionStats: [SchoolActionStat]
+    schoolActionStats(
+      "The school ID to display an action stat for."
+      schoolId: String
+    ): [SchoolActionStat]
   }
 
   "A media resource on a post."
@@ -293,6 +296,8 @@ const typeDefs = gql`
 
   "A set of aggregate post information for a school and action."
   type SchoolActionStat {
+    "The unique ID for this school action stat."
+    id: Int!
     "The school ID this stat belongs to"
     schoolId: String!
     "The action ID this stat belongs to."
@@ -412,9 +417,11 @@ const typeDefs = gql`
       "The number of results per page."
       count: Int = 20
     ): [Post]
-    schoolActionStatsBySchoolId(
+    schoolActionStats(
       "The School ID to filter school action stats by."
-      id: String!
+      schoolId: String
+      "The Action ID to filter school action stats by."
+      actionId: Int
     ): [SchoolActionStat]
     "Get a signup by ID."
     signup(id: Int!): Signup
@@ -528,7 +535,7 @@ const resolvers = {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
-      getActionStats({ actionId: action.id }, context),
+      getActionStats(args.schoolId, action.id, args.orderBy, context),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),
@@ -585,8 +592,8 @@ const resolvers = {
       getPostsByCampaignId(args.id, args.page, args.count, context),
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
-    schoolActionStatsBySchoolId: (_, args, context) =>
-      getActionStats({ schoolId: args.id }, context),
+    schoolActionStats: (_, args, context) =>
+      getActionStats(args.schoolId, args.actionId, args.orderBy, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -412,6 +412,10 @@ const typeDefs = gql`
       "The number of results per page."
       count: Int = 20
     ): [Post]
+    schoolActionStatsBySchoolId(
+      "The School ID to filter school action stats by."
+      id: String!
+    ): [SchoolActionStat]
     "Get a signup by ID."
     signup(id: Int!): Signup
     "Get a paginated collection of signups."
@@ -576,6 +580,7 @@ const resolvers = {
       getPostsByCampaignId(args.id, args.page, args.count, context),
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
+    schoolActionStatsBySchoolId: (_, args, context) => getActionStats({ schoolId: args.id }, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -9,6 +9,7 @@ import { urlWithQuery } from '../repositories/helpers';
 import OptionalFieldDirective from './directives/OptionalFieldDirective';
 import {
   getActionById,
+  getActionStats,
   getCampaigns,
   getPaginatedCampaigns,
   getPermalinkBySignupId,
@@ -163,6 +164,8 @@ const typeDefs = gql`
     updatedAt: DateTime
     "How long will this action take to complete?"
     timeCommitmentLabel: String
+    "Aggregate post information for this action by school."
+    schoolActionStats: [SchoolActionStat]
   }
 
   "A media resource on a post."
@@ -286,6 +289,22 @@ const typeDefs = gql`
     permalink: String
     "This flag is set when a signup has been deleted. On subsequent queries, this signup will be null."
     deleted: Boolean
+  }
+
+  "A set of aggregate post information for a school and action."
+  type SchoolActionStat {
+    "The school ID this stat belongs to"
+    schoolId: String!
+    "The action ID this stat belongs to."
+    actionId: Int!
+    "The action this stat belongs to."
+    action: Action!
+    "The sum quantity of all accepted posts with school and action."
+    acceptedQuantity: Int!
+    "The first time a post for school and action was reviewed."
+    createdAt: DateTime
+    "The last time a post for school and action was reviewed."
+    updatedAt: DateTime
   }
 
   type Query {
@@ -504,6 +523,7 @@ const resolvers = {
   Action: {
     campaign: (action, args, context, info) =>
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
+    schoolActionStats: (action, args, context) => getActionStats({ actionId: action.id }, context),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),


### PR DESCRIPTION
### What's this PR do?

This pull request supports the new Rogue `GET /action-stats` index endpoint added in https://github.com/DoSomething/rogue/pull/960 (and requires the tweaks added in https://github.com/DoSomething/rogue/pull/968) by adding a new `SchoolActionStat` type and fields:

* `Action.schoolActionStats` - returns a list of action stats for a given action ID, sorted by quantity descending. This is what we'll use for leaderboards, to get the list of schools with largest aggregate post quantity for the action.

* `School.schoolActionStats` - returns a list of action stats for a given school ID, sorted by ID descending. This is what we'll add to a School permalink (https://github.com/DoSomething/rogue/pull/953), to get the list of latest actions a school has taken, and also to display a selected school's impact in the School Finder after selecting a school (by passing an additional `actionId` parameter to filter results by).


### How should this be reviewed?

👀 

<img  alt="Screen Shot 2019-12-05 at 2 38 10 PM" src="https://user-images.githubusercontent.com/1236811/70280281-f0147200-176c-11ea-93ac-7d9f9b8a889d.png">


### Any background context you want to provide?

I left a TODO for pagination, as we won't need this for when we launch. Once there's time, it'd be nice to try out Relay Cursor Connections to have a better sense of how to weigh in on https://github.com/DoSomething/rfcs/pull/6.

### Relevant tickets

References [Pivotal #169659230](https://www.pivotaltracker.com/story/show/169659230), https://github.com/DoSomething/rogue/pull/964#discussion_r353974591

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
