### PR TITLE
Add 'createSignup' mutation.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -610,6 +610,33 @@ export const getSignupsByUserId = async (args, context) => {
 };
 
 /**
+ * Create a signup.
+ *
+ * @param {Number} signupId
+ * @return {Object}
+ */
+export const createSignup = async (args, context) => {
+  if (!args.campaignId) {
+    throw new Error(`Cannot create a signup without 'campaignId'.`);
+  }
+
+  logger.debug('Creating a signup', { args });
+
+  const response = await fetch(`${ROGUE_URL}/api/v3/signups`, {
+    method: 'POST',
+    ...requireAuthorizedRequest(context),
+    body: JSON.stringify({
+      campaign_id: args.campaignId,
+      details: args.details,
+    }),
+  });
+
+  const json = await response.json();
+
+  return transformItem(json);
+};
+
+/**
  * Delete a signup.
  *
  * @param {Number} signupId

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -1,4 +1,5 @@
 import { gql } from 'apollo-server';
+import GraphQLJSON from 'graphql-type-json';
 import { getFields } from 'fielddataloader';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 import { GraphQLDateTime } from 'graphql-iso-date';
@@ -33,6 +34,7 @@ import {
   tagPost,
   rotatePost,
   deletePost,
+  createSignup,
   deleteSignup,
 } from '../repositories/rogue';
 
@@ -42,6 +44,8 @@ import {
  * @var {String}
  */
 const typeDefs = gql`
+  scalar JSON
+
   scalar DateTime
 
   scalar AbsoluteUrl
@@ -549,6 +553,8 @@ const typeDefs = gql`
     ): Post
     "Delete a post. Requires staff/admin role."
     deletePost("The post ID to delete." id: Int!): Post
+    "Create a signup."
+    createSignup(campaignId: Int, detail: JSON): Signup
     "Delete a signup. Requires staff/admin role."
     deleteSignup("The signup ID to delete." id: Int!): Signup
   }
@@ -560,6 +566,7 @@ const typeDefs = gql`
  * @var {Object}
  */
 const resolvers = {
+  JSON: GraphQLJSON,
   DateTime: GraphQLDateTime,
   AbsoluteUrl: GraphQLAbsoluteUrl,
   Action: {
@@ -641,6 +648,7 @@ const resolvers = {
     rotatePost: (_, args, context) =>
       rotatePost(args.id, args.degrees, context),
     deletePost: (_, args, context) => deletePost(args.id, context),
+    createSignup: (_, args, context) => createSignup(args, context),
     deleteSignup: (_, args, context) => deleteSignup(args.id, context),
   },
   Campaign: {

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -554,7 +554,7 @@ const typeDefs = gql`
     "Delete a post. Requires staff/admin role."
     deletePost("The post ID to delete." id: Int!): Post
     "Create a signup."
-    createSignup(campaignId: Int, detail: JSON): Signup
+    createSignup(campaignId: Int!, detail: JSON): Signup
     "Delete a signup. Requires staff/admin role."
     deleteSignup("The signup ID to delete." id: Int!): Signup
   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `createSignup` mutation, allowing us to create signups via GraphQL.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is used in DoSomething/phoenix-next#1854.

### Relevant tickets

References [Pivotal #170053835](https://www.pivotaltracker.com/story/show/170053835).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
