### PR TITLE
Company Page Type & Qeury

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -23,6 +23,7 @@ import {
   getCampaignWebsiteByCampaignId,
   getCausePageBySlug,
   getCollectionPageBySlug,
+  getCompanyPageBySlug,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -83,6 +84,9 @@ export default (context, preview = false) => {
       ),
       collectionPagesBySlug: new DataLoader(slugs =>
         Promise.all(slugs.map(slug => getCollectionPageBySlug(slug, context))),
+      ),
+      companyPagesBySlug: new DataLoader(slugs =>
+        Promise.all(slugs.map(slug => getCompanyPageBySlug(slug, context))),
       ),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -174,6 +174,15 @@ export const getCollectionPageBySlug = async (slug, context) =>
   getPhoenixContentfulEntryByField('collectionPage', 'slug', slug, context);
 
 /**
+ * Search for a Phoenix Contentful Company Page entry by slug.
+ *
+ * @param {String} slug
+ * @return {Object}
+ */
+export const getCompanyPageBySlug = async (slug, context) =>
+  getPhoenixContentfulEntryByField('companyPage', 'slug', slug, context);
+
+/**
  * Search for a Phoenix Contentful affiliate entry by utmLabel.
  *
  * @param {String} id

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -115,7 +115,7 @@ const typeDefs = gql`
     subTitle: String
     "The cover image for this company page."
     coverImage: Asset
-    "The content, in Rich Text, for this company page."
+    "The Rich Text content for this company page."
     content: JSON!
     ${entryFields}
   }
@@ -231,9 +231,9 @@ const typeDefs = gql`
     superTitle: String!
     "The title."
     title: String!
-    "The description, in Rich Text."
+    "The Rich Text description."
     description: JSON!
-    "The content, in Rich Text."
+    "The Rich Text content."
     content: JSON!
     "Any custom overrides for this cause page."
     additionalContent: JSON
@@ -249,13 +249,13 @@ const typeDefs = gql`
     superTitle: String!
     "The title."
     title: String!
-    "The description, in Rich Text."
+    "The Rich Text description."
     description: JSON!
     "The prefix intro for the displayed affiliates."
     affiliatePrefix: String
     "The list of affiliates for this collection page."
     affiliates: [AffiliateBlock]
-    "The content, in Rich Text."
+    "The Rich Text content."
     content: JSON!
     ${entryFields}
   }

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -632,6 +632,7 @@ const typeDefs = gql`
     campaignWebsiteByCampaignId(campaignId: String!, preview: Boolean = false): CampaignWebsite
     causePageBySlug(slug: String!, preview: Boolean = false): CausePage
     collectionPageBySlug(slug: String!, preview: Boolean = false): CollectionPage
+    companyPageBySlug(slug: String!, preview: Boolean = false): CompanyPage
   }
 `;
 
@@ -695,6 +696,8 @@ const resolvers = {
       Loader(context, preview).causePagesBySlug.load(slug),
     collectionPageBySlug: (_, { slug, preview }, context) =>
       Loader(context, preview).collectionPagesBySlug.load(slug),
+    companyPageBySlug: (_, { slug, preview }, context) =>
+      Loader(context, preview).companyPagesBySlug.load(slug),
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -104,6 +104,22 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type CompanyPage {
+    "The internal-facing title for this company page."
+    internalTitle: String!
+    "The slug for this company page."
+    slug: String!
+    "The user-facing title for this company page."
+    title: String!
+    "The subtitle for this page."
+    subTitle: String
+    "The cover image for this company page."
+    coverImage: Asset
+    "The content, in Rich Text, for this company page."
+    content: JSON!
+    ${entryFields}
+  }
+
   enum CallToActionStyle {
     LIGHT
     DARK
@@ -652,6 +668,7 @@ const contentTypeMappings = {
   voterRegistrationAction: 'VoterRegistrationBlock',
   causePage: 'CausePage',
   collectionPage: 'CollectionPage',
+  companyPage: 'CompanyPage',
 };
 
 /**
@@ -726,6 +743,9 @@ const resolvers = {
   CollectionPage: {
     coverImage: linkResolver,
     affiliates: linkResolver,
+  },
+  CompanyPage: {
+    coverImage: linkResolver,
   },
   TextSubmissionBlock: {
     textFieldPlaceholderMessage: block => block.textFieldPlaceholder,

--- a/webhook.js
+++ b/webhook.js
@@ -58,6 +58,7 @@ exports.handler = async event => {
     campaign: ['legacyCampaignId'],
     causePage: ['slug'],
     collectionPage: ['slug'],
+    companyPage: ['slug'],
   };
 
   // Clear secondary cache key results from the Contentful cache if applicable.


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `CompanyPage` type to our contentful phoenix schema, as well as a query to fetch company pages by slug.

### How should this be reviewed?
👁 

### Any background context you want to provide?
This notably omits the [`metadata`](https://github.com/DoSomething/phoenix-next/blob/4288a6529a3bb2c5c375b0eaea53b8b753f6c802/contentful/content-types/companyPage.js#L64-L77) field. But we don't have any usage for it yet as a GraphQL rendered page on Phoenix, so it felt like overkill to include a new Type specifically for this field at this juncture.

I noticed that we seem to be repeating these 'find page by slug' repository methods, so it might eventually be opportune for us to consolidate those somehow? But in the interest of time, I ignored for now, but just noting! (Perhaps this could also apply to common page schema fields like `title`, `subTitle`, etc.)

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
