### PR TITLE
Cause Filter for Rogue Campaigns Query

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -4,7 +4,6 @@ import logger from 'heroku-logger';
 import { getFields } from 'fielddataloader';
 import {
   find,
-  has,
   intersection,
   isUndefined,
   omit,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -149,7 +149,7 @@ export const fetchCampaigns = async (
   const filter = omit(
     {
       is_open: args.isOpen,
-      has_cause: args.hasCause,
+      causes: args.causes ? args.causes.join(',') : undefined,
     },
     isUndefined,
   );

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -149,7 +149,7 @@ export const fetchCampaigns = async (
   const filter = omit(
     {
       is_open: args.isOpen,
-      causes: args.causes ? args.causes.join(',') : undefined,
+      cause: args.cause ? args.cause.join(',') : undefined,
     },
     isUndefined,
   );

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -2,7 +2,15 @@ import { stringify } from 'qs';
 import pluralize from 'pluralize';
 import logger from 'heroku-logger';
 import { getFields } from 'fielddataloader';
-import { find, has, intersection, snakeCase, zipWith } from 'lodash';
+import {
+  find,
+  has,
+  intersection,
+  isUndefined,
+  omit,
+  snakeCase,
+  zipWith,
+} from 'lodash';
 
 import schema from '../schema';
 import config from '../../config';
@@ -139,7 +147,13 @@ export const fetchCampaigns = async (
   info,
   additionalQuery = {},
 ) => {
-  const filter = has(args, 'isOpen') ? { is_open: args.isOpen } : undefined;
+  const filter = omit(
+    {
+      is_open: args.isOpen,
+      has_cause: args.hasCause,
+    },
+    isUndefined,
+  );
 
   // Rogue expects a comma-separated list of snake_case fields.
   // If not querying anything, use 'undefined' to omit query string.

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -347,7 +347,7 @@ const typeDefs = gql`
       "Only return campaigns that are open or closed."
       isOpen: Boolean
       "Only return campaigns containing these causes."
-      causes: [String]
+      cause: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -362,7 +362,7 @@ const typeDefs = gql`
       "Only return campaigns that are open or closed."
       isOpen: Boolean
       "Only return campaigns containing these causes."
-      causes: [String]
+      cause: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -346,8 +346,8 @@ const typeDefs = gql`
       page: Int = 1
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing this cause."
-      hasCause: String
+      "Only return campaigns containing these causes."
+      causes: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -361,8 +361,8 @@ const typeDefs = gql`
       after: String
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing this cause."
-      hasCause: String
+      "Only return campaigns containing these causes."
+      causes: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -346,6 +346,8 @@ const typeDefs = gql`
       page: Int = 1
       "Only return campaigns that are open or closed."
       isOpen: Boolean
+      "Only return campaigns containing this cause."
+      hasCause: String
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -359,6 +361,8 @@ const typeDefs = gql`
       after: String
       "Only return campaigns that are open or closed."
       isOpen: Boolean
+      "Only return campaigns containing this cause."
+      hasCause: String
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the `has_cause` filter to Rogue `campaigns` queries. 

Hat tip @DFurnes & @lindsayrmaher for this implementation idea!

Blocked by https://github.com/DoSomething/rogue/pull/985

### How should this be reviewed?
Think it's worth adding an `withoutUndefined` helper as we have in [Phoenix](https://github.com/DoSomething/phoenix-next/blob/eb2c9b11654ad3e5ac99bdc3af0b91e784008db7/resources/assets/helpers/index.js#L99-L107)?


### Relevant tickets

References [Pivotal #170734672](https://www.pivotaltracker.com/story/show/170734672).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
