### PR TITLE
Updating campaigns with campaignWebsite query capabilities

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -149,7 +149,7 @@ export const fetchCampaigns = async (
   const filter = omit(
     {
       is_open: args.isOpen,
-      cause: args.cause ? args.cause.join(',') : undefined,
+      has_cause: args.hasCause,
     },
     isUndefined,
   );

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -150,6 +150,7 @@ export const fetchCampaigns = async (
     {
       is_open: args.isOpen,
       causes: args.causes ? args.causes.join(',') : undefined,
+      has_website: args.hasWebsite,
     },
     isUndefined,
   );

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -149,7 +149,7 @@ export const fetchCampaigns = async (
   const filter = omit(
     {
       is_open: args.isOpen,
-      has_cause: args.hasCause,
+      causes: args.causes ? args.causes.join(',') : undefined,
     },
     isUndefined,
   );

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -410,7 +410,8 @@ const linkResolvers = {
 
   Campaign: {
     campaignWebsite: {
-      fragment: 'fragment CampaignWebsiteFragment on Campaign { contentfulCampaignId }',
+      fragment:
+        'fragment CampaignWebsiteFragment on Campaign { contentfulCampaignId }',
       resolve(campaign, args, context, info) {
         return info.mergeInfo.delegateToSchema({
           schema: phoenixContentfulSchema,
@@ -421,9 +422,9 @@ const linkResolvers = {
           },
           context,
           info,
-        })
-      }
-    }
+        });
+      },
+    },
   },
   Signup: {
     user: {

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -127,6 +127,11 @@ const linkSchema = gql`
     "The school that this school action stat is for."
     school: School
   }
+
+  extend type Campaign {
+    "The contentful campaign that is associated with the rogue campaign."
+    campaignWebsite: CampaignWebsite
+  }
 `;
 
 function blockActionResolver(blockTypeName) {
@@ -401,6 +406,24 @@ const linkResolvers = {
         });
       },
     },
+  },
+
+  Campaign: {
+    campaignWebsite: {
+      fragment: 'fragment CampaignWebsiteFragment on Campaign { contentfulCampaignId }',
+      resolve(campaign, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: phoenixContentfulSchema,
+          operation: 'query',
+          fieldName: 'campaignWebsite',
+          args: {
+            id: campaign.contentfulCampaignId,
+          },
+          context,
+          info,
+        })
+      }
+    }
   },
   Signup: {
     user: {

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -346,8 +346,8 @@ const typeDefs = gql`
       page: Int = 1
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing this cause."
-      hasCause: String
+      "Only return campaigns containing these causes."
+      causes: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -361,8 +361,8 @@ const typeDefs = gql`
       after: String
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing this cause."
-      hasCause: String
+      "Only return campaigns containing these causes."
+      causes: [String]
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -87,6 +87,8 @@ const typeDefs = gql`
     endDate: DateTime
     "The unique ID for this campaign."
     id: Int!
+    "The contentful campaign id where this campaign is being used."
+    contentfulCampaignId: String
     "The internal name used to identify the campaign."
     internalTitle: String!
     "Collection of Actions associated to the Campaign."
@@ -363,6 +365,8 @@ const typeDefs = gql`
       isOpen: Boolean
       "Only return campaigns containing these causes."
       causes: [String]
+      "Only return campaigns that have a contentful campaign associated."
+      hasWebsite: Boolean
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -346,8 +346,8 @@ const typeDefs = gql`
       page: Int = 1
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing these causes."
-      cause: [String]
+      "Only return campaigns containing this cause."
+      hasCause: String
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -361,8 +361,8 @@ const typeDefs = gql`
       after: String
       "Only return campaigns that are open or closed."
       isOpen: Boolean
-      "Only return campaigns containing these causes."
-      cause: [String]
+      "Only return campaigns containing this cause."
+      hasCause: String
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection


### PR DESCRIPTION
### What's this PR do?

This pull request adds capabilities to our paginated campaigns to be filtered by whether they have a contentful campaign id associated with them. It also adds a fragment to support a nested query of the campaignWebsite query in the contentful schema from inside the campaigns query. This gives us the ability to pull all the information about a campaign we need to filter and sort campaigns by a variety of parameters, while also displaying the correct contentful campaign info to the user!

### How should this be reviewed?

👀 I did rebase from Mendel's branch for his PR #190 so that I could use some of the logic he implemented in support for the cause filters. So there are a few lines of code in our PRs that overlap. FYI.

### Any background context you want to provide?

This is in support of the transition of the explore campaigns page from laravel to react and eventually to be able to filter those campaigns by cause! The hasWebsite filter won't return accurate results in QA or PROD until @mendelB is able to run the script to backfill all of our campaigns on rogue with their corresponding contentful campaign ids.

### Relevant tickets

References [Pivotal #171069006](https://www.pivotaltracker.com/story/show/171069006).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
