### PR TITLE
Add 'numberOfParticipantsFieldLabel' to PhotoSubmissionBlock.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -425,6 +425,8 @@ const typeDefs = gql`
     quantityFieldLabel: String
     "Optional placeholder for the quantity field."
     quantityFieldPlaceholder: String
+    "Optional label for the 'number_of_participants' field. If empty, this field will be omitted."
+    numberOfParticipantsFieldLabel: String
     "Optional label for the 'why participated' field."
     whyParticipatedFieldLabel: String
     "Optional placeholder for the 'why participated' field."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `numberOfParticipantsFieldLabel` field to `PhotoSubmissionBlock`. This was added to our PHP entity in DoSomething/phoenix-next#1599, but never added to our GraphQL schema or query for this component.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is breaking a sponsored campaign that relied on this behavior.

### Relevant tickets

References [Pivotal #171190942](https://www.pivotaltracker.com/story/show/171190942).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
