### PR TITLE
Add user deletion request field & mutations.

### DIFF
--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -175,6 +175,58 @@ export const updateSchoolId = async (id, schoolId, options) => {
 };
 
 /**
+ * Create a new "deletion request" for the given user.
+ *
+ * @param {String} id
+ * @param {Object} options
+ */
+export const requestDeletion = async (id, options) => {
+  logger.debug('Requesting deletion for user', { id });
+
+  try {
+    const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}/deletion`, {
+      method: 'POST',
+      ...requireAuthorizedRequest(options),
+    });
+
+    const json = await response.json();
+
+    return transformItem(json);
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to delete user.', { id, error });
+  }
+
+  return null;
+};
+
+/**
+ * Undo a "deletion request" for the given user.
+ *
+ * @param {String} id
+ * @param {Object} options
+ */
+export const undoDeletionRequest = async (id, options) => {
+  logger.debug('Undoing deletion request for user', { id });
+
+  try {
+    const response = await fetch(`${NORTHSTAR_URL}/v2/users/${id}/deletion`, {
+      method: 'DELETE',
+      ...requireAuthorizedRequest(options),
+    });
+
+    const json = await response.json();
+
+    return transformItem(json);
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to undo deletetion request for user.', { id, error });
+  }
+
+  return null;
+};
+
+/**
  * Get Aurora profile permalink by ID.
  *
  * @param {String} id

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -12,6 +12,8 @@ import { stringToEnum, listToEnums } from './helpers';
 import {
   updateEmailSubscriptionTopics,
   getPermalinkByUserId,
+  undoDeletionRequest,
+  requestDeletion,
   updateSchoolId,
   getUsers,
 } from '../repositories/northstar';
@@ -128,6 +130,8 @@ const typeDefs = gql`
     schoolId: String @sensitive @optional
     "The user's voter registration status, either self-reported or by registering with TurboVote."
     voterRegistrationStatus: VoterRegistrationStatus
+    "If the user has requested their account to be deleted, this is the time that request occurred."
+    deletionRequestedAt: DateTime
     "The time this user was created. See the 'source' and 'source_detail' field for details."
     createdAt: DateTime
     "The last modified time for this user account."
@@ -159,6 +163,13 @@ const typeDefs = gql`
   }
 
   type Mutation {
+    "Request deletion for the given user account."
+    requestDeletion("The user ID to request deletion for." id: String!): User!
+    "Request deletion for the given user account."
+    undoDeletionRequest(
+      "The user ID whose request we're undoing."
+      id: String!
+    ): User!
     "Update the list of newsletters a user is subscribed to."
     updateEmailSubscriptionTopics(
       "The user to update."
@@ -201,6 +212,9 @@ const resolvers = {
   DateTime: GraphQLDateTime,
   AbsoluteUrl: GraphQLAbsoluteUrl,
   Mutation: {
+    requestDeletion: (_, args, context) => requestDeletion(args.id, context),
+    undoDeletionRequest: (_, args, context) =>
+      undoDeletionRequest(args.id, context),
     updateEmailSubscriptionTopics: (_, args, context) =>
       updateEmailSubscriptionTopics(
         args.id,


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `User.deletionRequestedAt` field and the `requestDeletion` and `undoDeletionRequest` mutations. These 

### How should this be reviewed?

👀

### Any background context you want to provide?

This simply exposes the REST endpoints added in DoSomething/northstar#984.

### Relevant tickets

References [Pivotal #170953839](https://www.pivotaltracker.com/story/show/170953839).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
