### PR TITLE
Adding homepage schema

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -89,7 +89,7 @@ export default (context, preview = false) => {
       companyPagesBySlug: new DataLoader(slugs =>
         Promise.all(slugs.map(slug => getCompanyPageBySlug(slug, context))),
       ),
-      homePages: getHomePage(context),
+      homePage: getHomePage(context),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
       ),

--- a/src/loader.js
+++ b/src/loader.js
@@ -17,14 +17,14 @@ import {
 } from './repositories/contentful/gambit';
 import { authorizedRequest } from './repositories/helpers';
 import {
+  getHomePage,
+  getCausePageBySlug,
+  getCompanyPageBySlug,
+  getAffiliateByUtmLabel,
+  getCollectionPageBySlug,
   getPhoenixContentfulAssetById,
   getPhoenixContentfulEntryById,
-  getAffiliateByUtmLabel,
   getCampaignWebsiteByCampaignId,
-  getCausePageBySlug,
-  getCollectionPageBySlug,
-  getCompanyPageBySlug,
-  getHomePage,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -89,7 +89,7 @@ export default (context, preview = false) => {
       companyPagesBySlug: new DataLoader(slugs =>
         Promise.all(slugs.map(slug => getCompanyPageBySlug(slug, context))),
       ),
-      homePage: new DataLoader(entries => Promise.all(entries.shift())),
+      homePages: getHomePage(context),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
       ),

--- a/src/loader.js
+++ b/src/loader.js
@@ -24,6 +24,7 @@ import {
   getCausePageBySlug,
   getCollectionPageBySlug,
   getCompanyPageBySlug,
+  getHomePage,
 } from './repositories/contentful/phoenix';
 
 /**
@@ -88,6 +89,7 @@ export default (context, preview = false) => {
       companyPagesBySlug: new DataLoader(slugs =>
         Promise.all(slugs.map(slug => getCompanyPageBySlug(slug, context))),
       ),
+      homePage: new DataLoader(entries => Promise.all(entries.shift())),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
       ),

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -146,6 +146,26 @@ export const getPhoenixContentfulEntryByField = async (
   });
 };
 
+export const getHomePage = async () => {
+  console.log('💅');
+
+  const query = {
+    content_type: homePage,
+    order: '-sys.updatedAt',
+    limit: 1,
+  };
+
+  // Choose the right cache and API for this request:
+  const cache = preview ? previewCache : contentCache;
+  const api = preview ? previewApi : contentApi;
+
+  const json = await api.getEntries(query);
+
+  console.log(json);
+
+  return null;
+};
+
 /**
  * Search for a Phoenix Contentful Campaign entry by campaignId.
  *

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -175,7 +175,6 @@ export const getHomePage = async context => {
       const json = await api.getEntries(query);
 
       const item = json.items[0];
-      console.log(item);
 
       if (!item) {
         return null;

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -146,24 +146,53 @@ export const getPhoenixContentfulEntryByField = async (
   });
 };
 
-export const getHomePage = async () => {
-  console.log('💅');
+/**
+ * Search for a Phoenix Contentful HomePage entry.
+ *
+ * @param {Object} context
+ */
+export const getHomePage = async context => {
+  const { preview } = context;
 
   const query = {
-    content_type: homePage,
+    content_type: 'homePage',
     order: '-sys.updatedAt',
     limit: 1,
   };
+
+  logger.debug('Loading Contentful HomePage entry', {
+    query,
+    preview,
+  });
 
   // Choose the right cache and API for this request:
   const cache = preview ? previewCache : contentCache;
   const api = preview ? previewApi : contentApi;
 
-  const json = await api.getEntries(query);
+  // Read from cache or Contentful's Content API:
+  return cache.remember(`homePage:${spaceId}`, async () => {
+    try {
+      const json = await api.getEntries(query);
 
-  console.log(json);
+      const item = json.items[0];
+      console.log(item);
 
-  return null;
+      if (!item) {
+        return null;
+      }
+
+      return transformItem(item);
+    } catch (exception) {
+      logger.warn('Unable to load Contentful HomePage entry', {
+        query,
+        spaceId,
+        preview,
+        error: exception.message,
+      });
+    }
+
+    return null;
+  });
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -737,7 +737,7 @@ const resolvers = {
       Loader(context, preview).collectionPagesBySlug.load(slug),
     companyPageBySlug: (_, { slug, preview }, context) =>
       Loader(context, preview).companyPagesBySlug.load(slug),
-    homePage: (_, { preview }, context) => Loader(context, preview).homePages,
+    homePage: (_, { preview }, context) => Loader(context, preview).homePage,
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -222,6 +222,22 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type HomePage {
+    "This title is used internally to help find this content."
+    internalTitle: String!
+    "The title for this page."
+    title: String!
+    "The subtitle for this page."
+    subTitle: String
+    "Campaigns (campaign and story page entries) rendered as a list on the homepage."
+    campaigns: [CampaignWebsite]
+    "Articles (page entries) rendered as a list on the homepage."
+    articles: [Page]
+    "Any custom overrides for this entry."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
   type CausePage {
     "The slug for this cause page."
     slug: String!
@@ -662,19 +678,22 @@ const typeDefs = gql`
  * @var {Object}
  */
 const contentTypeMappings = {
-  affirmation: 'AffirmationBlock',
   affiliates: 'AffiliateBlock',
-  campaign: 'CampaignWebsite',
+  affirmation: 'AffirmationBlock',
   callToAction: 'CallToActionBlock',
+  campaign: 'CampaignWebsite',
   campaignDashboard: 'CampaignDashboard',
   campaignUpdate: 'CampaignUpdateBlock',
-  page: 'Page',
-  embed: 'EmbedBlock',
+  causePage: 'CausePage',
+  collectionPage: 'CollectionPage',
+  companyPage: 'CompanyPage',
   contentBlock: 'ContentBlock',
   currentSchoolBlock: 'CurrentSchoolBlock',
+  embed: 'EmbedBlock',
   galleryBlock: 'GalleryBlock',
   imagesBlock: 'ImagesBlock',
   linkAction: 'LinkBlock',
+  page: 'Page',
   person: 'PersonBlock',
   petitionSubmissionAction: 'PetitionSubmissionBlock',
   photoSubmissionAction: 'PhotoSubmissionBlock',
@@ -682,15 +701,12 @@ const contentTypeMappings = {
   quiz: 'QuizBlock',
   sectionBlock: 'SectionBlock',
   selectionSubmissionAction: 'SelectionSubmissionBlock',
+  shareAction: 'ShareBlock',
   sixpackExperiment: 'SixpackExperimentBlock',
   socialDriveAction: 'SocialDriveBlock',
-  shareAction: 'ShareBlock',
   softEdgeWidgetAction: 'SoftEdgeBlock',
   textSubmissionAction: 'TextSubmissionBlock',
   voterRegistrationAction: 'VoterRegistrationBlock',
-  causePage: 'CausePage',
-  collectionPage: 'CollectionPage',
-  companyPage: 'CompanyPage',
 };
 
 /**

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -222,22 +222,6 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type HomePage {
-    "This title is used internally to help find this content."
-    internalTitle: String!
-    "The title for this page."
-    title: String!
-    "The subtitle for this page."
-    subTitle: String
-    "Campaigns (campaign and story page entries) rendered as a list on the homepage."
-    campaigns: [CampaignWebsite]
-    "Articles (page entries) rendered as a list on the homepage."
-    articles: [Page]
-    "Any custom overrides for this entry."
-    additionalContent: JSON
-    ${entryFields}
-  }
-
   type CausePage {
     "The slug for this cause page."
     slug: String!
@@ -273,6 +257,22 @@ const typeDefs = gql`
     affiliates: [AffiliateBlock]
     "The Rich Text content."
     content: JSON!
+    ${entryFields}
+  }
+
+  type HomePage {
+    "This title is used internally to help find this content."
+    internalTitle: String!
+    "The title for this page."
+    title: String!
+    "The subtitle for this page."
+    subTitle: String
+    "Campaigns (campaign and story page entries) rendered as a list on the homepage."
+    campaigns: [CampaignWebsite]
+    "Articles (page entries) rendered as a list on the homepage."
+    articles: [Page]
+    "Any custom overrides for this entry."
+    additionalContent: JSON
     ${entryFields}
   }
 
@@ -669,6 +669,7 @@ const typeDefs = gql`
     causePageBySlug(slug: String!, preview: Boolean = false): CausePage
     collectionPageBySlug(slug: String!, preview: Boolean = false): CollectionPage
     companyPageBySlug(slug: String!, preview: Boolean = false): CompanyPage
+    homePage(preview: Boolean = false): HomePage
   }
 `;
 
@@ -691,6 +692,7 @@ const contentTypeMappings = {
   currentSchoolBlock: 'CurrentSchoolBlock',
   embed: 'EmbedBlock',
   galleryBlock: 'GalleryBlock',
+  homePage: 'HomePage',
   imagesBlock: 'ImagesBlock',
   linkAction: 'LinkBlock',
   page: 'Page',
@@ -735,6 +737,7 @@ const resolvers = {
       Loader(context, preview).collectionPagesBySlug.load(slug),
     companyPageBySlug: (_, { slug, preview }, context) =>
       Loader(context, preview).companyPagesBySlug.load(slug),
+    homePage: (_, { preview }) => Loader(preview).homePage.load(),
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },
@@ -811,6 +814,10 @@ const resolvers = {
     blocks: linkResolver,
     imageAlignment: block => stringToEnum(block.imageAlignment),
     imageFit: block => stringToEnum(block.imageFit),
+  },
+  HomePage: {
+    articles: linkResolver,
+    campaigns: linkResolver,
   },
   ImagesBlock: {
     images: linkResolver,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -9,8 +9,8 @@ import config from '../../../config';
 import Loader from '../../loader';
 import { stringToEnum, listToEnums } from '../helpers';
 import {
-  createImageUrl,
   linkResolver,
+  createImageUrl,
   parseQuizResults,
   parseQuizQuestions,
 } from '../../repositories/contentful/phoenix';
@@ -737,7 +737,7 @@ const resolvers = {
       Loader(context, preview).collectionPagesBySlug.load(slug),
     companyPageBySlug: (_, { slug, preview }, context) =>
       Loader(context, preview).companyPagesBySlug.load(slug),
-    homePage: (_, { preview }) => Loader(preview).homePage.load(),
+    homePage: (_, { preview }, context) => Loader(context, preview).homePages,
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
   },


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `HomePage` type to the schema and related resolvers to allow returning a response of the latest `homePage` entry in Contentful with any related query fields.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #171056180](https://www.pivotaltracker.com/story/show/171056180).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
