### PR TITLE
Adds StoryPageWebsite type and ResourceWebsite union to GraphQL.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -89,10 +89,6 @@ export default (context, preview = false) => {
       companyPagesBySlug: new DataLoader(slugs =>
         Promise.all(slugs.map(slug => getCompanyPageBySlug(slug, context))),
       ),
-      homePage: getHomePage(context),
-      pages: new DataLoader(ids =>
-        Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
-      ),
       conversations: new DataLoader(ids =>
         Promise.all(ids.map(id => getConversationById(id, options))),
       ),
@@ -102,12 +98,19 @@ export default (context, preview = false) => {
       gambitAssets: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulAssetById(id, context))),
       ),
-      users: new FieldDataLoader((id, fields) =>
-        getUserById(id, fields, context),
+      homePage: getHomePage(context),
+      pages: new DataLoader(ids =>
+        Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
       ),
       signups: new DataLoader(ids => getSignupsById(ids, options)),
+      storyPageWebsites: new DataLoader(ids =>
+        Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
+      ),
       topics: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulEntryById(id, options))),
+      ),
+      users: new FieldDataLoader((id, fields) =>
+        getUserById(id, fields, context),
       ),
     };
   }

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -681,6 +681,7 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  "A web-based campaign interface, such as the traditional campaign template or story page."
   union ResourceWebsite = CampaignWebsite | StoryPageWebsite
 
   type Query {

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -1,12 +1,12 @@
-import { makeExecutableSchema } from 'graphql-tools';
-import { GraphQLDateTime } from 'graphql-iso-date';
-import { GraphQLAbsoluteUrl } from 'graphql-url';
-import GraphQLJSON from 'graphql-type-json';
-import { gql } from 'apollo-server';
 import { get, first } from 'lodash';
+import { gql } from 'apollo-server';
+import GraphQLJSON from 'graphql-type-json';
+import { GraphQLAbsoluteUrl } from 'graphql-url';
+import { GraphQLDateTime } from 'graphql-iso-date';
+import { makeExecutableSchema } from 'graphql-tools';
 
-import config from '../../../config';
 import Loader from '../../loader';
+import config from '../../../config';
 import { stringToEnum, listToEnums } from '../helpers';
 import {
   linkResolver,
@@ -117,6 +117,30 @@ const typeDefs = gql`
     coverImage: Asset
     "The Rich Text content for this company page."
     content: JSON!
+    ${entryFields}
+  }
+
+  type StoryPageWebsite implements Showcasable {
+    "The internal-facing title for this story campaign."
+    internalTitle: String!
+    "The slug for this story campaign."
+    slug: String!
+    "The URL for this story campaign."
+    url: String!
+    "The user-facing title for this story campaign."
+    title: String!
+    "The user-facing subtitle for this story campaign."
+    subTitle: String
+    "The cover image for this story campaign."
+    coverImage: Asset
+    "Blocks rendered following the initial content on the story campaign."
+    blocks: [Block]
+    "The showcase title (the title field.)"
+    showcaseTitle: String!
+    "The showcase description (the subTitle field.)"
+    showcaseDescription: String!
+    "The showcase image (the coverImage field.)"
+    showcaseImage: Asset
     ${entryFields}
   }
 
@@ -268,7 +292,7 @@ const typeDefs = gql`
     "The subtitle for this page."
     subTitle: String
     "Campaigns (campaign and story page entries) rendered as a list on the homepage."
-    campaigns: [CampaignWebsite]
+    campaigns: [ResourceWebsite]
     "Articles (page entries) rendered as a list on the homepage."
     articles: [Page]
     "Any custom overrides for this entry."
@@ -657,6 +681,8 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  union ResourceWebsite = CampaignWebsite | StoryPageWebsite
+
   type Query {
     "Get a block by ID."
     block(id: String!, preview: Boolean = false): Block
@@ -670,6 +696,7 @@ const typeDefs = gql`
     collectionPageBySlug(slug: String!, preview: Boolean = false): CollectionPage
     companyPageBySlug(slug: String!, preview: Boolean = false): CompanyPage
     homePage(preview: Boolean = false): HomePage
+    storyPageWebsite(id: String!, preview: Boolean = false): StoryPageWebsite
   }
 `;
 
@@ -707,6 +734,7 @@ const contentTypeMappings = {
   sixpackExperiment: 'SixpackExperimentBlock',
   socialDriveAction: 'SocialDriveBlock',
   softEdgeWidgetAction: 'SoftEdgeBlock',
+  storyPage: 'StoryPageWebsite',
   textSubmissionAction: 'TextSubmissionBlock',
   voterRegistrationAction: 'VoterRegistrationBlock',
 };
@@ -740,6 +768,11 @@ const resolvers = {
     homePage: (_, { preview }, context) => Loader(context, preview).homePage,
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
+    storyPageWebsite: (_, { id, preview }, context) =>
+      Loader(context, preview).storyPageWebsites.load(id),
+  },
+  AffiliateBlock: {
+    logo: linkResolver,
   },
   AffirmationBlock: {
     author: (person, _, context, info) =>
@@ -751,20 +784,8 @@ const resolvers = {
   Block: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
   },
-  Showcasable: {
-    __resolveType: showcasable =>
-      get(contentTypeMappings, showcasable.contentType),
-  },
   CallToActionBlock: {
     visualStyle: block => first(listToEnums(block.visualStyle)) || 'DARK',
-  },
-  ContentBlock: {
-    image: linkResolver,
-    imageAlignment: block => stringToEnum(block.imageAlignment),
-    showcaseTitle: content => content.title,
-    showcaseDescription: content => content.content,
-    showcaseImage: (person, _, context, info) =>
-      linkResolver(person, _, context, info, 'image'),
   },
   CampaignUpdateBlock: {
     author: linkResolver,
@@ -775,8 +796,8 @@ const resolvers = {
     coverImage: linkResolver,
     showcaseTitle: campaign => campaign.title,
     showcaseDescription: campaign => campaign.callToAction,
-    showcaseImage: (person, _, context, info) =>
-      linkResolver(person, _, context, info, 'coverImage'),
+    showcaseImage: (campaign, _, context, info) =>
+      linkResolver(campaign, _, context, info, 'coverImage'),
     url: campaign =>
       `${config('services.phoenix.url')}/us/campaigns/${campaign.slug}`,
   },
@@ -790,25 +811,16 @@ const resolvers = {
   CompanyPage: {
     coverImage: linkResolver,
   },
-  TextSubmissionBlock: {
-    textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
+  ContentBlock: {
+    image: linkResolver,
+    imageAlignment: block => stringToEnum(block.imageAlignment),
+    showcaseTitle: content => content.title,
+    showcaseDescription: content => content.content,
+    showcaseImage: (person, _, context, info) =>
+      linkResolver(person, _, context, info, 'image'),
   },
-  PetitionSubmissionBlock: {
-    textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
-  },
-  SixpackExperimentBlock: {
-    control: linkResolver,
-    alternatives: linkResolver,
-    convertableActions: block => listToEnums(block.convertableActions),
-  },
-  SelectionSubmissionBlock: {
-    richText: block => block.content,
-  },
-  ShareBlock: {
-    affirmationBlock: linkResolver,
-  },
-  LinkBlock: {
-    affiliateLogo: linkResolver,
+  EmbedBlock: {
+    previewImage: linkResolver,
   },
   GalleryBlock: {
     blocks: linkResolver,
@@ -821,6 +833,18 @@ const resolvers = {
   },
   ImagesBlock: {
     images: linkResolver,
+  },
+  LinkBlock: {
+    affiliateLogo: linkResolver,
+  },
+  Page: {
+    coverImage: linkResolver,
+    showcaseTitle: page => page.title,
+    showcaseDescription: page => page.subTitle,
+    showcaseImage: (page, _, context, info) =>
+      linkResolver(page, _, context, info, 'coverImage'),
+    blocks: linkResolver,
+    sidebar: linkResolver,
   },
   PersonBlock: {
     photo: linkResolver,
@@ -837,26 +861,44 @@ const resolvers = {
       return linkResolver(person, _, context, info, fieldName);
     },
   },
-  EmbedBlock: {
-    previewImage: linkResolver,
+  PetitionSubmissionBlock: {
+    textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
   },
-  Page: {
+  ResourceWebsite: {
+    __resolveType: block => get(contentTypeMappings, block.contentType),
+  },
+  SelectionSubmissionBlock: {
+    richText: block => block.content,
+  },
+  ShareBlock: {
+    affirmationBlock: linkResolver,
+  },
+  Showcasable: {
+    __resolveType: showcasable =>
+      get(contentTypeMappings, showcasable.contentType),
+  },
+  SixpackExperimentBlock: {
+    control: linkResolver,
+    alternatives: linkResolver,
+    convertableActions: block => listToEnums(block.convertableActions),
+  },
+  StoryPageWebsite: {
     coverImage: linkResolver,
-    showcaseTitle: page => page.title,
-    showcaseDescription: page => page.subTitle,
-    showcaseImage: (page, _, context, info) =>
-      linkResolver(page, _, context, info, 'coverImage'),
     blocks: linkResolver,
-    sidebar: linkResolver,
+    showcaseTitle: storyPage => storyPage.title,
+    showcaseDescription: storyPage => storyPage.subtitle,
+    showcaseImage: (storyPage, _, context, info) =>
+      linkResolver(storyPage, _, context, info, 'coverImage'),
+    url: storyPage => `${config('services.phoenix.url')}/us/${storyPage.slug}`,
+  },
+  TextSubmissionBlock: {
+    textFieldPlaceholderMessage: block => block.textFieldPlaceholder,
   },
   QuizBlock: {
     resultBlocks: linkResolver,
     defaultResultBlock: linkResolver,
     questions: parseQuizQuestions,
     results: parseQuizResults,
-  },
-  AffiliateBlock: {
-    logo: linkResolver,
   },
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `StoryPageWebsite` type to the GraphQL schema, since the home page `campaigns` list can contain `Campaign` and `StoryPage` content types, that is similar to the existing `CampaignWebsite` type.

It also includes a new [`union` type](https://graphql.org/learn/schema/#union-types) to allow resolving a query with either a `CampaignWebsite` or a `StoryPageWebsite`.

Along with this there's a bit of cleanup along with alphabetizing the resolvers.

### How should this be reviewed?

👀 


### Relevant tickets

References [Pivotal #171056180](https://www.pivotaltracker.com/story/show/171056180).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
