### PR TITLE
Individual subscription mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4794,8 +4794,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4816,14 +4815,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4838,20 +4835,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4968,8 +4962,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4981,7 +4974,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4996,7 +4988,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5004,14 +4995,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5030,7 +5019,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5111,8 +5099,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5124,7 +5111,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5210,8 +5196,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5247,7 +5232,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5267,7 +5251,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5311,14 +5294,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9000,8 +8981,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -146,7 +146,6 @@ export const updateEmailSubscriptionTopics = async (
  * @param {String} id
  * @param {EmailSubscriptionTopic} topic
  * @param {Boolean} subscribed
- *
  * @param {Object} options
  */
 export const updateEmailSubscriptionTopic = async (

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -171,7 +171,6 @@ export const updateEmailSubscriptionTopic = async (
     );
 
     const json = await response.json();
-    console.log(json);
 
     return transformItem(json);
   } catch (exception) {

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -163,7 +163,7 @@ export const updateEmailSubscriptionTopic = async (
 
   try {
     const response = await fetch(
-      `${NORTHSTAR_URL}/v2/users/${id}/subscriptions/${topic}`,
+      `${NORTHSTAR_URL}/v2/users/${id}/subscriptions/${topic.toLowerCase()}`,
       {
         method: subscribed ? 'POST' : 'DELETE',
         ...requireAuthorizedRequest(options),

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -141,6 +141,49 @@ export const updateEmailSubscriptionTopics = async (
 };
 
 /**
+ * Update a user's subscription status to a specific email newsletter.
+ *
+ * @param {String} id
+ * @param {EmailSubscriptionTopic} topic
+ * @param {Boolean} subscribed
+ *
+ * @param {Object} options
+ */
+export const updateEmailSubscriptionTopic = async (
+  id,
+  topic,
+  subscribed,
+  options,
+) => {
+  logger.debug('Updating email subscription topic for user in Northstar', {
+    id,
+  });
+
+  try {
+    const response = await fetch(
+      `${NORTHSTAR_URL}/v2/users/${id}/subscriptions/${topic}`,
+      {
+        method: subscribed ? 'POST' : 'DELETE',
+        ...requireAuthorizedRequest(options),
+      },
+    );
+
+    const json = await response.json();
+    console.log(json);
+
+    return transformItem(json);
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to update subscription status for topic.', {
+      id,
+      error,
+    });
+  }
+
+  return null;
+};
+
+/**
  * Update a user's school_id in Northstar.
  *
  * @param {String} id

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -157,6 +157,8 @@ export const updateEmailSubscriptionTopic = async (
 ) => {
   logger.debug('Updating email subscription topic for user in Northstar', {
     id,
+    topic,
+    subscribed,
   });
 
   try {

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -232,7 +232,12 @@ const resolvers = {
         context,
       ),
     updateEmailSubscriptionTopic: (_, args, context) =>
-      updateEmailSubscriptionTopic(args.id, args.topic, context),
+      updateEmailSubscriptionTopic(
+        args.id,
+        args.topic,
+        args.subscribed,
+        context,
+      ),
     updateSchoolId: (_, args, context) =>
       updateSchoolId(args.id, args.schoolId, context),
   },

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -182,7 +182,7 @@ const typeDefs = gql`
     updateEmailSubscriptionTopic(
       "The user to update."
       id: String!
-      "The newsletter the user should be subscribed to."
+      "The newsletter the to update the subscription status of."
       topic: EmailSubscriptionTopic!
       "The new subscription status."
       subscribed: Boolean!

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -11,6 +11,7 @@ import OptionalFieldDirective from './directives/OptionalFieldDirective';
 import { stringToEnum, listToEnums } from './helpers';
 import {
   updateEmailSubscriptionTopics,
+  updateEmailSubscriptionTopic,
   getPermalinkByUserId,
   undoDeletionRequest,
   requestDeletion,
@@ -177,6 +178,15 @@ const typeDefs = gql`
       "The newsletters the user should be subscribed to."
       emailSubscriptionTopics: [EmailSubscriptionTopic]!
     ): User!
+    "Update the user's subscription for a given newsletter."
+    updateEmailSubscriptionTopic(
+      "The user to update."
+      id: String!
+      "The newsletter the user should be subscribed to."
+      topic: EmailSubscriptionTopic!
+      "The new subscription status."
+      subscribed: Boolean!
+    ): User!
     "Update the user school id."
     updateSchoolId(
       "The user to update."
@@ -221,6 +231,8 @@ const resolvers = {
         args.emailSubscriptionTopics,
         context,
       ),
+    updateEmailSubscriptionTopic: (_, args, context) =>
+      updateEmailSubscriptionTopic(args.id, args.topic, context),
     updateSchoolId: (_, args, context) =>
       updateSchoolId(args.id, args.schoolId, context),
   },


### PR DESCRIPTION
### What's this PR do?
Adds a new mutation that allows for individual email subscriptions to be added or removed. Ties into new northstar resources at `/v2/users/:id/subscriptions/:topic`

### How should this be reviewed?

Test out the mutation in the playground:
```
mutation {
  updateEmailSubscriptionTopic(
    id: "NS_ID",
    topic: NEWS,
    subscribed: false,
  ) {
    id
    emailSubscriptionTopics
  }
}
```

### Relevant tickets

References [Pivotal #171544273](https://www.pivotaltracker.com/story/show/171544273).
