### PR TITLE
Add volunteer_credit field to Rogue Action schema

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -157,6 +157,8 @@ const typeDefs = gql`
     quiz: Boolean
     "Does this action count as a scholarship entry?"
     scholarshipEntry: Boolean
+    "Does this action qualify for volunteer credit?"
+    volunteerCredit: Boolean
     "Does this action associate user posts with their school?"
     collectSchoolId: Boolean
     "Anonymous actions will not be attributed to a particular user in public galleries."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `volunteer_credit` field to the Rogue Action schema

### How should this be reviewed?
👀 

### Any background context you want to provide?
This fields was added in https://github.com/DoSomething/rogue/pull/995
and we'll want to query it in the Action component in https://github.com/DoSomething/rogue/pull/996

### Relevant tickets

References [Pivotal #171455025](https://www.pivotaltracker.com/story/show/171455025).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
