### PR TITLE
Add Causes mutation for Users to update their profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4794,7 +4794,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4815,12 +4816,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4835,17 +4838,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4962,7 +4968,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4974,6 +4981,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4988,6 +4996,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4995,12 +5004,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5019,6 +5030,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5099,7 +5111,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5111,6 +5124,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5196,7 +5210,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5232,6 +5247,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5251,6 +5267,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5294,12 +5311,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8981,7 +9000,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -184,6 +184,48 @@ export const updateEmailSubscriptionTopic = async (
 };
 
 /**
+ * Update a user's list of causes they are interested in.
+ *
+ * @param {String} id
+ * @param {Cause} cause
+ * @param {Boolean} interested
+ * @param {Object} options
+ */
+export const updateCausePreferences = async (
+  id,
+  cause,
+  interested,
+  options,
+) => {
+  logger.debug('Updating cause for user in Northstar', {
+    id,
+    cause
+  });
+
+  try {
+    const response = await fetch(
+      `${NORTHSTAR_URL}/v2/users/${id}/subscriptions/${cause.toLowerCase()}`,
+      {
+        method: interested ? 'POST' : 'DELETE',
+        ...requireAuthorizedRequest(options),
+      },
+    );
+
+    const json = await response.json();
+
+    return transformItem(json);
+  } catch (exception) {
+    const error = exception.message;
+    logger.warn('Unable to update causes preferences for this cause.', {
+      id,
+      error,
+    });
+  }
+
+  return null;
+};
+
+/**
  * Update a user's school_id in Northstar.
  *
  * @param {String} id

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -204,7 +204,7 @@ export const updateCausePreferences = async (
 
   try {
     const response = await fetch(
-      `${NORTHSTAR_URL}/v2/users/${id}/subscriptions/${cause.toLowerCase()}`,
+      `${NORTHSTAR_URL}/v2/users/${id}/causes/${cause.toLowerCase()}`,
       {
         method: interested ? 'POST' : 'DELETE',
         ...requireAuthorizedRequest(options),
@@ -212,7 +212,7 @@ export const updateCausePreferences = async (
     );
 
     const json = await response.json();
-
+    
     return transformItem(json);
   } catch (exception) {
     const error = exception.message;

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -200,6 +200,7 @@ export const updateCausePreferences = async (
   logger.debug('Updating cause for user in Northstar', {
     id,
     cause,
+    interested,
   });
 
   try {

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -199,7 +199,7 @@ export const updateCausePreferences = async (
 ) => {
   logger.debug('Updating cause for user in Northstar', {
     id,
-    cause
+    cause,
   });
 
   try {
@@ -212,7 +212,7 @@ export const updateCausePreferences = async (
     );
 
     const json = await response.json();
-    
+
     return transformItem(json);
   } catch (exception) {
     const error = exception.message;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -267,12 +267,7 @@ const resolvers = {
         context,
       ),
     updateCausePreferences: (_, args, context) =>
-        updateCausePreferences(
-          args.id,
-          args.cause,
-          args.interested,
-          context
-        ),
+      updateCausePreferences(args.id, args.cause, args.interested, context),
     updateSchoolId: (_, args, context) =>
       updateSchoolId(args.id, args.schoolId, context),
   },

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -77,7 +77,7 @@ const typeDefs = gql`
   }
 
   "The user's choices of cause area preference."
-  enum Cause {
+  enum CauseIdentifier {
     ANIMAL_WELFARE
     BULLYING
     EDUCATION
@@ -173,7 +173,7 @@ const typeDefs = gql`
     "The permalink to this user's profile in Aurora."
     permalink: String @requires(fields: "id")
     "The causes areas this user is interested in."
-    causes: [Cause]
+    causes: [CauseIdentifier]
   }
 
   type Query {
@@ -218,7 +218,8 @@ const typeDefs = gql`
       "The user to update."
       id: String!
       "The cause area to update the preference of."
-      cause: Cause!
+      cause: CauseIdentifier!
+      interested: Boolean!
     ): User!
   }
 `;

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -10,6 +10,7 @@ import SensitiveFieldDirective from './directives/SensitiveFieldDirective';
 import OptionalFieldDirective from './directives/OptionalFieldDirective';
 import { stringToEnum, listToEnums } from './helpers';
 import {
+  updateCausePreferences,
   updateEmailSubscriptionTopics,
   updateEmailSubscriptionTopic,
   getPermalinkByUserId,
@@ -73,6 +74,22 @@ const typeDefs = gql`
     COMMUNITY
     SCHOLARSHIPS
     LIFESTYLE
+  }
+
+  "The user's choices of cause area preference."
+  enum Cause {
+    ANIMAL_WELFARE
+    BULLYING
+    EDUCATION
+    ENVIRONMENT
+    GENDER_RIGHTS_EQUALITY
+    HOMELESSNESS_POVERTY
+    IMMIGRATION_REFUGEES
+    LGBTQ_RIGHTS_EQUALITY
+    MENTAL_HEALTH
+    PHYSICAL_HEALTH
+    RACIAL_JUSTICE_EQUITY
+    SEXUAL_HARASSMENT_ASSAULT
   }
 
   "A DoSomething.org user profile."
@@ -155,6 +172,8 @@ const typeDefs = gql`
     hasFeatureFlag(feature: String): Boolean @requires(fields: "featureFlags")
     "The permalink to this user's profile in Aurora."
     permalink: String @requires(fields: "id")
+    "The causes areas this user is interested in."
+    causes: [Cause]
   }
 
   type Query {
@@ -194,6 +213,13 @@ const typeDefs = gql`
       "The school_id to save to the user."
       schoolId: String
     ): User!
+    "Update the user's cause interest preferences."
+    updateCausePreferences(
+      "The user to update."
+      id: String!
+      "The cause area to update the preference of."
+      cause: Cause!
+    ): User!
   }
 `;
 
@@ -212,6 +238,7 @@ const resolvers = {
     hasFeatureFlag: (user, { feature }) =>
       has(user, `featureFlags.${feature}`) &&
       user.featureFlags[feature] !== false,
+    causes: user => listToEnums(user.causes),
   },
   Query: {
     user: (_, { id }, context, info) =>
@@ -238,6 +265,13 @@ const resolvers = {
         args.subscribed,
         context,
       ),
+    updateCausePreferences: (_, args, context) =>
+        updateCausePreferences(
+          args.id,
+          args.cause,
+          args.interested,
+          context
+        ),
     updateSchoolId: (_, args, context) =>
       updateSchoolId(args.id, args.schoolId, context),
   },


### PR DESCRIPTION
### What's this PR do?

This pull request adds a mutation to the NS schema to allow users to update their causes interests preferences via their Phoenix profile!! 

### How should this be reviewed?

Make sure the mutation, resolver makes sense. and of course just any feedback on structure, quick fixes etc

### Any background context you want to provide?

This is a follow up to the work last week adding the endpoints in NS!

### Relevant tickets

References [Pivotal # 171580885](https://www.pivotaltracker.com/story/show/171580885).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
