### PR TITLE
Add 'pageBySlug' query & 'Page.authors' field.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -18,6 +18,7 @@ import {
 import { authorizedRequest } from './repositories/helpers';
 import {
   getHomePage,
+  getPageBySlug,
   getCausePageBySlug,
   getCompanyPageBySlug,
   getAffiliateByUtmLabel,
@@ -101,6 +102,9 @@ export default (context, preview = false) => {
       homePage: getHomePage(context),
       pages: new DataLoader(ids =>
         Promise.all(ids.map(id => getPhoenixContentfulEntryById(id, context))),
+      ),
+      pagesBySlug: new DataLoader(slugs =>
+        Promise.all(slugs.map(slug => getPageBySlug(slug, context))),
       ),
       signups: new DataLoader(ids => getSignupsById(ids, options)),
       storyPageWebsites: new DataLoader(ids =>

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -204,6 +204,15 @@ export const getCampaignWebsiteByCampaignId = async (id, context) =>
   getPhoenixContentfulEntryByField('campaign', 'legacyCampaignId', id, context);
 
 /**
+ * Search for a Phoenix Contentful Page entry by slug.
+ *
+ * @param {String} slug
+ * @return {Object}
+ */
+export const getPageBySlug = async (slug, context) =>
+  getPhoenixContentfulEntryByField('page', 'slug', slug, context);
+
+/**
  * Search for a Phoenix Contentful Cause Page entry by slug.
  *
  * @param {String} slug

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -225,6 +225,8 @@ const typeDefs = gql`
     slug: String!
     "Cover image for this page."
     coverImage: Asset
+    "The authors for this page."
+    authors: [PersonBlock]
     "The content of the page."
     content: String
     "Sidebar blocks rendered alongside the content on the page."
@@ -842,6 +844,7 @@ const resolvers = {
     affiliateLogo: linkResolver,
   },
   Page: {
+    authors: linkResolver,
     coverImage: linkResolver,
     showcaseTitle: page => page.title,
     showcaseDescription: page => page.subTitle,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -692,6 +692,7 @@ const typeDefs = gql`
     affiliate(utmLabel: String!, preview: Boolean = false): AffiliateBlock
     campaignWebsite(id: String!, preview: Boolean = false): CampaignWebsite
     page(id: String!, preview: Boolean = false): Page
+    pageBySlug(slug: String!, preview: Boolean = false): Page
     campaignWebsiteByCampaignId(campaignId: String!, preview: Boolean = false): CampaignWebsite
     causePageBySlug(slug: String!, preview: Boolean = false): CausePage
     collectionPageBySlug(slug: String!, preview: Boolean = false): CollectionPage
@@ -769,6 +770,8 @@ const resolvers = {
     homePage: (_, { preview }, context) => Loader(context, preview).homePage,
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
+    pageBySlug: (_, { slug, preview }, context) =>
+      Loader(context, preview).pagesBySlug.load(slug),
     storyPageWebsite: (_, { id, preview }, context) =>
       Loader(context, preview).storyPageWebsites.load(id),
   },

--- a/webhook.js
+++ b/webhook.js
@@ -71,6 +71,7 @@ exports.handler = async event => {
     causePage: ['slug'],
     collectionPage: ['slug'],
     companyPage: ['slug'],
+    page: ['slug'],
   };
 
   // Clear secondary cache key results from the Contentful cache if applicable.


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `pageBySlug` query to allow us to load a page by its slug (e.g. `facts/11-facts-about-volcanoes`) and the `Page.authors` reference field to load the authors of a given page.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is used as part of my server-side rendering prototypes.

### Relevant tickets

References [Pivotal #171650956](https://www.pivotaltracker.com/story/show/171650956).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
