### PR TITLE
Phoenix LinkBlock link field type definition

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -391,7 +391,7 @@ const typeDefs = gql`
     "Optional description of the link."
     content: String
     "The URL (or tel: number) being linked to."
-    # @TODO: use a custom scalar to validate the link as an AbsoluteUrl or 'tel:' String.
+    # @TODO: Update this value to be some combination of AbsoluteUrl and valid 'tel:' String.
     link: String!
     "Optional custom text to display on the submission button."
     buttonText: String

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -387,12 +387,12 @@ const typeDefs = gql`
 
   type LinkBlock implements Block {
     "The user-facing title for this link block."
-    title: String
+    title: String!
     "Optional description of the link."
     content: String
     "The URL (or tel: number) being linked to."
     # @TODO: use a custom scalar to validate the link as an AbsoluteUrl or 'tel:' String.
-    link: String
+    link: String!
     "Optional custom text to display on the submission button."
     buttonText: String
     "The logo of the partner or sponsor for this link action."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -390,8 +390,9 @@ const typeDefs = gql`
     title: String
     "Optional description of the link."
     content: String
-    "The URL being linked to."
-    link: AbsoluteUrl
+    "The URL (or tel: number) being linked to."
+    # @TODO: use a custom scalar to validate the link as an AbsoluteUrl or 'tel:' String.
+    link: String
     "Optional custom text to display on the submission button."
     buttonText: String
     "The logo of the partner or sponsor for this link action."


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Contentful Phoenix `LinkBlock`'s `link` field to be a `String` instead of an `AbsoluteUrl`. (It also marks the `link` & `title` fields as required since they're required fields on the Contentful model)

### How should this be reviewed?
👀 

### Any background context you want to provide?
We [accept](https://user-images.githubusercontent.com/12417657/76890993-a86aaf80-685e-11ea-8f77-706198ec445b.png) `tel:[phone-number]` as valid values for this field, for e.g. 'Call Your Representative' phone actions.

The dream would be to have a union custom scalar that properly validates this field as either a `GraphQLAbsoluteUrl` or a validated `tel` string.


### Relevant tickets

References [Pivotal #171824364](https://www.pivotaltracker.com/story/show/171824364).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/76891208-f97aa380-685e-11ea-812e-0c3ae38c7963.png)

