### PR TITLE
Add volunteer_credit filter to Rogue posts query

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -232,6 +232,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       status: args.status,
       tag: args.tags ? args.tags.join(',') : undefined,
       type: args.type,
+      volunteer_credit: args.volunteerCredit,
     },
     ...additionalQuery,
   });

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -6,8 +6,8 @@ import { GraphQLDateTime } from 'graphql-iso-date';
 import { makeExecutableSchema } from 'graphql-tools';
 
 import Loader from '../loader';
-import { urlWithQuery } from '../repositories/helpers';
 import OptionalFieldDirective from './directives/OptionalFieldDirective';
+import { urlWithQuery, transformItem } from '../repositories/helpers';
 import {
   getActionById,
   getActionStats,
@@ -600,7 +600,7 @@ const resolvers = {
     url: (post, args) => urlWithQuery(post.media.url, args),
     text: post => post.media.text,
     status: post => post.status.toUpperCase().replace('-', '_'),
-    actionDetails: post => post.actionDetails.data,
+    actionDetails: post => transformItem(post.actionDetails),
     location: (post, { format }) => {
       switch (format) {
         case 'HUMAN_FORMAT':

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -396,6 +396,8 @@ const typeDefs = gql`
       type: String
       "The user ID to load posts for."
       userId: String
+      "Filter by the corresponding Action's volunteer credit status"
+      volunteerCredit: Boolean
       "The page of results to return."
       page: Int = 1
       "The number of results per page."
@@ -423,6 +425,8 @@ const typeDefs = gql`
       type: String
       "The user ID to load posts for."
       userId: String
+      "Filter by the corresponding Action's volunteer credit status"
+      volunteerCredit: Boolean
       "Get the first N results."
       first: Int = 20
       "The cursor to return results after."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `volunteer_credit` filter to both `posts` and `paginatedPosts` queries.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We've added this filter in Rogue https://github.com/DoSomething/rogue/pull/1000. This will allow us to pull in the desired posts to formulate a 'rewards' table in Phoenix.

![image](https://user-images.githubusercontent.com/12417657/77075963-817cbc80-69c9-11ea-91d6-a80564649f6d.png)

I bumped into an issue where our `transformResponse` helper doesn't transform the nested [`actionDatails`](https://github.com/DoSomething/graphql/blob/53806590a533f2863a096c4e9b0c0dccfa1d9083/src/schema/rogue.js#L208) response field, and thus, all Action fields are not camel-cased, which means we can't explicitly query for any non-single-word field. So I cannot prove that this query is indeed filtering for Posts whos Actions _are_ `volunteer_credit`. But trust me. I've never let you down. ~(Oh and I'll add a follow-up PR with a resolver for this field so it can actually work!)~

Oop! Updated in https://github.com/DoSomething/graphql/pull/206/commits/b25ff22873b380293c3aff3fb0ee3abbde7a32fe so that the `actionDetails` field actually gets transformed, so we can query it's multi-word fields (and now you can see the filter working!):
![image](https://user-images.githubusercontent.com/12417657/77078176-9c046500-69cc-11ea-985a-66d75580efeb.png)



### Relevant tickets

References [Pivotal #171729071](https://www.pivotaltracker.com/story/show/171729071).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
