### PR TITLE
Post Query Status Field Update 

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -14,6 +14,7 @@ import {
 import schema from '../schema';
 import config from '../../config';
 import Collection from './Collection';
+import { enumToString } from '../schema/helpers';
 import {
   getOptional,
   transformItem,
@@ -229,7 +230,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       location: args.location,
       northstar_id: args.userId,
       source: args.source,
-      status: args.status,
+      status: args.status ? args.status.map(enumToString).join(',') : undefined,
       tag: args.tags ? args.tags.join(',') : undefined,
       type: args.type,
     },

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -1,4 +1,4 @@
-import { snakeCase } from 'lodash';
+import { snakeCase, kebabCase } from 'lodash';
 
 /**
  * Transform a string constant into a GraphQL-style enum.
@@ -26,4 +26,18 @@ export const listToEnums = list => {
   }
 
   return list.map(stringToEnum);
+};
+
+/**
+ * Transform a GraphQL-style enum into a hyphen-separated, lower-case string.
+ *
+ * @param  {String} enumArg
+ * @return {String}
+ */
+export const enumToString = enumArg => {
+  if (!enumArg) {
+    return null;
+  }
+
+  return kebabCase(enumArg).toLowerCase();
 };

--- a/src/schema/helpers.js
+++ b/src/schema/helpers.js
@@ -29,7 +29,7 @@ export const listToEnums = list => {
 };
 
 /**
- * Transform a GraphQL-style enum into a hyphen-separated, lower-case string.
+ * Transform a GraphQL-style enum into a kebab-case string.
  *
  * @param  {String} enumArg
  * @return {String}
@@ -39,5 +39,5 @@ export const enumToString = enumArg => {
     return null;
   }
 
-  return kebabCase(enumArg).toLowerCase();
+  return kebabCase(enumArg);
 };

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -386,8 +386,8 @@ const typeDefs = gql`
       signupId: String
       "The location to load posts for."
       location: String
-      "The post status to load posts for."
-      status: String
+      "The post statuses to load posts for."
+      status: [ReviewStatus]
       "The post source to load posts for."
       source: String
       "The tags to load posts for."
@@ -413,8 +413,8 @@ const typeDefs = gql`
       signupId: String
       "The location to load posts for."
       location: String
-      "The post status to load posts for."
-      status: String
+      "The post statuses to load posts for."
+      status: [ReviewStatus]
       "The post source to load posts for."
       source: String
       "The tags to load posts for."


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Rogue `/posts` queries' `status` field to be a list of the `ReviewStatus` enums. 

### How should this be reviewed?
How's that new helper? Is this implemented correctly?

### Any background context you want to provide?
We realized that this `status` field is really a [multi-status filter](https://git.io/Jv19I) so it should be a list. [And also](https://dosomething.slack.com/archives/CUQMU4Q6B/p1584632069034600?thread_ts=1584631130.033600&cid=CUQMU4Q6B) that it should use the handily existing `ReviewStatus` enum.

Since it's now necessary to transform the enums into the correct format for the Rogue API, I gleaned inspiration from https://github.com/DoSomething/graphql/pull/203#discussion_r393116544 to add an `enumToString` helper we can use. (You can see the list of Rogue statuses [here](https://github.com/DoSomething/rogue/blob/94508b66fca8f5da0e5240fd3b85d69d16fbbf41/app/Http/Requests/PostRequest.php#L70-L93)).

According to our [Apollo metrics](https://engine.apollographql.com/graph/dosomething-graphql-lambda/metrics?query=4034cf12333295618e7529f1466f602a81890301&queryName=ReviewablePostsQuery&range=lastMonth&schemaTag=current&search=%24status&tab=operation) there's only one query [on Rogue](https://github.com/DoSomething/rogue/blob/94508b66fca8f5da0e5240fd3b85d69d16fbbf41/resources/assets/components/ReviewablePostGallery.js#L16) that's using this filter, so we can reasonabely implement this breaking change in coordination with an update on Rogue (PR impending.)

### Relevant tickets

References [Pivotal #171729071](https://www.pivotaltracker.com/story/show/171729071).
https://dosomething.slack.com/archives/CUQMU4Q6B/p1584631130033600

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
