### PR TITLE
Adds referrerUserId

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -732,6 +732,7 @@ export const getPostsCount = async (args, context) => {
       campaign_id: args.campaignId,
       location: args.location,
       northstar_id: args.userId,
+      referrer_user_id: args.referrerUserId,
       source: args.source,
       type: args.type,
       tag: args.tags,

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -146,8 +146,10 @@ const typeDefs = gql`
     role: Role
     "The user's current School ID"
     schoolId: String @sensitive @optional
-    "The user's voter registration status, either self-reported or by registering with TurboVote."
+    "The user's voter registration status, either self-reported or by registering with third-party."
     voterRegistrationStatus: VoterRegistrationStatus
+    "The user who referred this user to create an account."
+    referrerUserId: String
     "If the user has requested their account to be deleted, this is the time that request occurred."
     deletionRequestedAt: DateTime
     "The time this user was created. See the 'source' and 'source_detail' field for details."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -525,6 +525,8 @@ const typeDefs = gql`
       campaignId: String
       "The location to count posts for."
       location: String
+      "# The referring User ID to count posts for."
+      referrerUserId: String
       "# The post source to count posts for."
       source: String
       "# The type name to count posts for."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -234,6 +234,8 @@ const typeDefs = gql`
     status: ReviewStatus
     "The source of this post. This is often a Northstar OAuth client."
     source: String
+    "The user who referred the post user to create this post."
+    referrerUserId: String
     "The number of items added or removed in this post."
     quantity: Int
     "The human-readable impact (quantity, noun, and verb)."
@@ -295,6 +297,8 @@ const typeDefs = gql`
     sourceDetails: String
     "More information about the signup (for example, third-party messaging opt-ins)."
     details: String
+    "The user who referred the signup user to create this signup."
+    referrerUserId: String
     "The time this signup was last modified."
     updatedAt: DateTime
     "The time when this signup was originally created."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `referrerUserId` field added to Users (https://github.com/DoSomething/northstar/pull/1000), Signups, and Posts (https://github.com/DoSomething/rogue/pull/1003), and makes it available as an argument to count posts for, so we'll be able to display a user's total number of voter registration referrals:

Example request:
```
{
  postsCount(
    referrerUserId: "5dd8d818fdce276a557e5894"
    type: "voter-reg"
    limit: 50
  )
}
```

Example response:
```
{
  "data": {
    "postsCount": 6
  },
  ...

```
### How should this be reviewed?

👀 

### Any background context you want to provide?

🛋 

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/n/projects/2417735/stories/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
