### PR TITLE
Adds status parameter to getPostsCount 

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -735,6 +735,7 @@ export const getPostsCount = async (args, context) => {
       northstar_id: args.userId,
       referrer_user_id: args.referrerUserId,
       source: args.source,
+      status: args.status ? args.status.map(enumToString).join(',') : undefined,
       type: args.type,
       tag: args.tags,
     },

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -521,23 +521,23 @@ const typeDefs = gql`
       action: String
       "The action IDs to count posts for."
       actionIds: [Int]
-      "# The campaign ID to count posts for."
+      "The campaign ID to count posts for."
       campaignId: String
       "The location to count posts for."
       location: String
-      "# The referring User ID to count posts for."
+      "The referring User ID to count posts for."
       referrerUserId: String
-      "# The post source to count posts for."
+      "The post source to count posts for."
       source: String
       "The post statuses to count posts for."
       status: [ReviewStatus]
-      "# The type name to count posts for."
+      "The type name to count posts for."
       type: String
-      "# The user ID to count posts for."
+      "The user ID to count posts for."
       userId: String
       "A comma-separated list of tags to filter by."
       tags: String
-      "# The maximum count to report."
+      "The maximum count to report."
       limit: Int = 20
     ): Int
   }

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -529,6 +529,8 @@ const typeDefs = gql`
       referrerUserId: String
       "# The post source to count posts for."
       source: String
+      "The post statuses to count posts for."
+      status: [ReviewStatus]
       "# The type name to count posts for."
       type: String
       "# The user ID to count posts for."


### PR DESCRIPTION
### What's this PR do?

This pull request allows adding `status` as a filter for the `getPostsCount` query, which we need for displaying the total number of *completed* voter registration referrals (as well as the referrer user ID that we added in #208).

Refs https://github.com/DoSomething/phoenix-next/pull/1998

Example query:
```
{
  postsCount(
    referrerUserId: "5dd8d818fdce276a557e5894"
    status: [REGISTER_FORM, REGISTER_OVR]
    limit: 50
  )
}

```

### How should this be reviewed?

👀 

### Any background context you want to provide?

Also removes the unnecessary `#` prefix in schema definition per  https://github.com/DoSomething/graphql/pull/208#discussion_r398145570.

### Relevant tickets

References [Pivotal #2417735](https://www.pivotaltracker.com/n/projects/2417735).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
