### PR TITLE
Updates to enabled additional homepage features.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -96,6 +96,8 @@ const typeDefs = gql`
     "The cover image for this campaign."
     coverImage: Asset
     "The showcase title (the title field.)"
+    staffPick: Boolean
+    "Designates if this is a staff pick campaign."
     showcaseTitle: String!
     "The showcase description (the callToAction field.)"
     showcaseDescription: String!
@@ -289,15 +291,17 @@ const typeDefs = gql`
   type HomePage {
     "This title is used internally to help find this content."
     internalTitle: String!
-    "The title for this page."
+    "The title for the home page."
     title: String!
-    "The subtitle for this page."
+    "The subtitle for the home page."
     subTitle: String
-    "Campaigns (campaign and story page entries) rendered as a list on the homepage."
+    "Cover image for the home page."
+    coverImage: Asset
+    "Campaigns (campaign and story page entries) rendered as a list on the home page."
     campaigns: [ResourceWebsite]
-    "Articles (page entries) rendered as a list on the homepage."
+    "Articles (page entries) rendered as a list on the home page."
     articles: [Page]
-    "Any custom overrides for this entry."
+    "Any custom overrides for the home page."
     additionalContent: JSON
     ${entryFields}
   }
@@ -835,6 +839,7 @@ const resolvers = {
     imageFit: block => stringToEnum(block.imageFit),
   },
   HomePage: {
+    coverImage: linkResolver,
     articles: linkResolver,
     campaigns: linkResolver,
   },


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `HomePage` type to include retrieving the `coverImage` field (will be added as Contentful migration script in upcoming Phoenix PR) and to also include the `staffPick` boolean field for the `CampaignWebsite` type, so we can designate a campaign in the gallery as "featured".

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #171336897](https://www.pivotaltracker.com/story/show/171336897).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
