### PR TITLE
Filter posts by referrerUserId

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -229,6 +229,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       signup_id: args.signupId,
       location: args.location,
       northstar_id: args.userId,
+      referrer_user_id: args.referrerUserId,
       source: args.source,
       status: args.status ? args.status.map(enumToString).join(',') : undefined,
       tag: args.tags ? args.tags.join(',') : undefined,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -390,6 +390,8 @@ const typeDefs = gql`
       signupId: String
       "The location to load posts for."
       location: String
+      "The referring User ID to load posts for."
+      referrerUserId: String
       "The post statuses to load posts for."
       status: [ReviewStatus]
       "The post source to load posts for."
@@ -419,6 +421,8 @@ const typeDefs = gql`
       signupId: String
       "The location to load posts for."
       location: String
+      "The referring User ID to load posts for."
+      referrerUserId: String
       "The post statuses to load posts for."
       status: [ReviewStatus]
       "The post source to load posts for."


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to filter a list of posts by `referrerUserId`. Refs https://github.com/DoSomething/graphql/pull/209

### How should this be reviewed?

Example request:
```
{
  posts(referrerUserId: "5dd8d818fdce276a557e5894") {
    id
    userId
    referrerUserId
    status
    type
  }
}

```
Example response:
```
{
  "data": {
    "posts": [
      {
        "id": 1824,
        "userId": "5e7fb6a7fdce2730a2178d02",
        "referrerUserId": "5dd8d818fdce276a557e5894",
        "status": "UNCERTAIN",
        "type": "voter-reg"
      },
      {
        "id": 1822,
        "userId": "5e7b9f3dfdce274d614819fc",
        "referrerUserId": "5dd8d818fdce276a557e5894",
        "status": "UNCERTAIN",
        "type": "voter-reg"
      },
      ...
```

### Any background context you want to provide?

Looking to display a list of a user's referrals in Rogue to help spot check voter registration referrals.

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
