### PR TITLE
Send additional context to Apollo Engine for debugging.

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,6 +16,12 @@ const server = new ApolloServer({
   context: ({ event }) => ({
     authorization: event.headers.Authorization || event.headers.authorization,
   }),
+  engine: {
+    apiKey: process.env.ENGINE_API_KEY,
+
+    // Record some common non-sensitive variables for debugging in Apollo Engine:
+    sendVariableValues: { onlyNames: ['id', 'preview', 'campaignId', 'slug'] },
+  },
 });
 
 exports.handler = (event, context, callback) => {

--- a/main.js
+++ b/main.js
@@ -42,7 +42,12 @@ exports.handler = (event, context, callback) => {
     cors: {
       origin: '*',
       credentials: true,
-      allowedHeaders: ['content-type', 'authorization'],
+      allowedHeaders: [
+        'content-type',
+        'authorization',
+        'apollographql-client-name',
+        'apollographql-client-version',
+      ],
     },
   };
 


### PR DESCRIPTION
### What's this PR do?

This pull request whitelists some known non-sensitive variables to be included in Apollo Engine metrics. This will give us some more context to use when debugging a failing query.

It also whitelists the `apollographql-client-name` and `apollographql-client-version` in our CORS settings, which allow clients to include them for [additional report segmentation](https://www.apollographql.com/docs/graph-manager/client-awareness/).

### How should this be reviewed?

Double-check my configuration syntax, and then we can test it out on dev!

### Any background context you want to provide?

This configuration option is described under [`EngineReportingOptions`](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions). The additional whitelisted CORS headers should fix up this error when including client metadata:

```
Failed to load resource: Request header field apollographql-client-name is not allowed by Access-Control-Allow-Headers.
```

### Relevant tickets

References [Pivotal #171001230](https://www.pivotaltracker.com/story/show/171001230).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
