### PR TITLE
Adds new status values for voter registration

### DIFF
--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -62,10 +62,16 @@ const typeDefs = gql`
   }
 
   enum VoterRegistrationStatus {
-    REGISTRATION_COMPLETE
     CONFIRMED
     INELIGIBLE
+    REJECTED
+    REGISTRATION_COMPLETE
+    STEP_1
+    STEP_2
+    STEP_3
+    STEP_4
     UNCERTAIN
+    UNDER_18
     UNREGISTERED
   }
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -57,13 +57,18 @@ const typeDefs = gql`
   "Posts are reviewed by DoSomething.org staff for content."
   enum ReviewStatus {
     ACCEPTED
-    REJECTED
+    CONFIRMED
+    INELIGIBLE
     PENDING
     REGISTER_FORM
     REGISTER_OVR
-    CONFIRMED
-    INELIGIBLE
+    REJECTED
+    STEP_1
+    STEP_2
+    STEP_3
+    STEP_4
     UNCERTAIN
+    UNDER_18
   }
 
   enum LocationFormat {


### PR DESCRIPTION
### What's this PR do?

This pull request updates our enumerations for a user's `voter_registration_status` per https://github.com/DoSomething/northstar/pull/1005, and a `voter-reg` post status per `https://github.com/DoSomething/rogue/pull/1011`. The updated values are a result of the changes made to the Rock The Vote import in https://github.com/DoSomething/chompy/pull/153

### How should this be reviewed?

👀 

### Any background context you want to provide?

🍇 

### Relevant tickets

References [Pivotal #171737617](https://www.pivotaltracker.com/story/show/171737617).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
