### PR TITLE
Adds the new CTA block to phoenix schema

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -181,16 +181,18 @@ const typeDefs = gql`
   type CallToActionBlock implements Block {
     "The small title above the main CTA title"
     superTitle: String
+    "The main, large title of the CTA"
     title: String
-    "The content of the call to action."
+    "The paragraph that follows the title."
     content: String
+    "The text label of the CTA button"
     linkText: String
+    "The destination of the CTA link"
     link: String
+    "The visual style of the CTA block"
     template: CallToActionTemplate
+    "The alignment of all the text in the CTA block"
     alignment: CallToActionAlignment
-
-
-
     "The visual treatment to apply to this block."
     visualStyle: CallToActionStyle @deprecated(reason: "Outdated component pieces")
     "Use the campaign tagline as the first line of the CTA (if on a campaign page)."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -167,21 +167,42 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  enum CallToActionTemplate {
+    PURPLE
+    YELLOW
+    VOTER_REGISTRATION
+  }
+
+  enum CallToActionAlignment {
+    LEFT
+    CENTER
+  }
+
   type CallToActionBlock implements Block {
-    "The visual treatment to apply to this block."
-    visualStyle: CallToActionStyle
-    "Use the campaign tagline as the first line of the CTA (if on a campaign page)."
-    useCampaignTagline: Boolean
+    "The small title above the main CTA title"
+    superTitle: String
+    title: String
     "The content of the call to action."
     content: String
+    linkText: String
+    link: String
+    template: CallToActionTemplate
+    alignment: CallToActionAlignment
+
+
+
+    "The visual treatment to apply to this block."
+    visualStyle: CallToActionStyle @deprecated(reason: "Outdated component pieces")
+    "Use the campaign tagline as the first line of the CTA (if on a campaign page)."
+    useCampaignTagline: Boolean @deprecated(reason: "Outdated component pieces")
     "The content to display before the impact value."
-    impactPrefix: String
+    impactPrefix: String @deprecated(reason: "Outdated component pieces")
     "The emphasized 'impact' value."
-    impactValue: String
+    impactValue: String @deprecated(reason: "Outdated component pieces")
     "The content to display after the impact value."
-    impactSuffix: String
+    impactSuffix: String @deprecated(reason: "Outdated component pieces")
     "The button text."
-    actionText: String
+    actionText: String @deprecated(reason: "Outdated component pieces")
     ${blockFields}
     ${entryFields}
   }
@@ -797,6 +818,8 @@ const resolvers = {
   },
   CallToActionBlock: {
     visualStyle: block => first(listToEnums(block.visualStyle)) || 'DARK',
+    template: block => stringToEnum(block.template),
+    alignment: block => stringToEnum(block.alignment),
   },
   CampaignUpdateBlock: {
     author: linkResolver,


### PR DESCRIPTION
### What's this PR do?

This pull request adds new fields to the Phoenix schema to support the new CTA component.

### How should this be reviewed?

👀 - This is linked to this [migration PR in Phoenix](https://github.com/DoSomething/phoenix-next/pull/2055)

### Any background context you want to provide?

This supports an overhaul of the new Call to Action block that will be placed on marketing pages

### Relevant tickets

References [Pivotal #172203389]().