### PR TITLE
Add affiliateSponsor field to Phoenix CampaignWebsite

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -103,6 +103,8 @@ const typeDefs = gql`
     showcaseDescription: String!
     "The showcase image (the coverImage field.)"
     showcaseImage: Asset
+    "The affiliate sponsors for this campaign."
+    affiliateSponsors: [AffiliateBlock]
     ${entryFields}
   }
 
@@ -828,6 +830,7 @@ const resolvers = {
     affiliateLogo: linkResolver,
   },
   CampaignWebsite: {
+    affiliateSponsors: linkResolver,
     affirmation: linkResolver,
     coverImage: linkResolver,
     showcaseTitle: campaign => campaign.title,


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `affiliateSponsors` field to the `CampaignWebsite` type in Phoenix Contentful schema

### How should this be reviewed?
👀 

### Any background context you want to provide?
We need this for the [Volunteer Credit Certificate](https://github.com/DoSomething/phoenix-next/blob/21b4ab553a41b7a8f0feab917ac361ae271d70f8/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js#L109-L123) over in Phoenix

### Relevant tickets

References [Pivotal #172544320](https://www.pivotaltracker.com/story/show/172544320).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/80636839-0f69af80-8a2c-11ea-97fa-eb5c0c53e012.png)

```js
campaignWebsite(id: "4P1isZqnSEM8aggmIgmaAs") {
  affiliateSponsors {
    logo {
      url
      description
    }
  }
}
```
