### PR TITLE
Additional CampaignWebsite fields

### DIFF
--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -1,5 +1,4 @@
 import { URL } from 'url';
-import { mapKeys } from 'lodash';
 import logger from 'heroku-logger';
 import { createClient } from 'contentful';
 

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -33,21 +33,13 @@ const previewApi = createClient({
  * @param {Object} json
  * @return {Object}
  */
-const transformItem = json => {
-  const fields = json.fields;
-
-  if (fields.legacyCampaignId) {
-    fields.campaignId = fields.legacyCampaignId;
-  }
-
-  return {
-    id: json.sys.id,
-    contentType: json.sys.contentType.sys.id,
-    createdAt: json.sys.createdAt,
-    updatedAt: json.sys.updatedAt,
-    ...fields,
-  };
-}
+const transformItem = json => ({
+  id: json.sys.id,
+  contentType: json.sys.contentType.sys.id,
+  createdAt: json.sys.createdAt,
+  updatedAt: json.sys.updatedAt,
+  ...json.fields,
+});
 
 /**
  * @param {Object} json

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -1,6 +1,7 @@
-import { createClient } from 'contentful';
-import logger from 'heroku-logger';
 import { URL } from 'url';
+import { mapKeys } from 'lodash';
+import logger from 'heroku-logger';
+import { createClient } from 'contentful';
 
 import { urlWithQuery } from '../helpers';
 import config from '../../../config';
@@ -33,13 +34,21 @@ const previewApi = createClient({
  * @param {Object} json
  * @return {Object}
  */
-const transformItem = json => ({
-  id: json.sys.id,
-  contentType: json.sys.contentType.sys.id,
-  createdAt: json.sys.createdAt,
-  updatedAt: json.sys.updatedAt,
-  ...json.fields,
-});
+const transformItem = json => {
+  const fields = json.fields;
+
+  if (fields.legacyCampaignId) {
+    fields.campaignId = fields.legacyCampaignId;
+  }
+
+  return {
+    id: json.sys.id,
+    contentType: json.sys.contentType.sys.id,
+    createdAt: json.sys.createdAt,
+    updatedAt: json.sys.updatedAt,
+    ...fields,
+  };
+}
 
 /**
  * @param {Object} json

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -93,8 +93,12 @@ const typeDefs = gql`
     affirmation: Block
     "The call to action tagline for this campaign."
     callToAction: String!
+     "The totally NOT legacy / actual Rogue campaign ID associated with this campaign website."
+    legacyCampaignId: Int
     "The cover image for this campaign."
     coverImage: Asset
+     "The scholarship amount associated with this campaign."
+    scholarshipAmount: Int
     "The showcase title (the title field.)"
     staffPick: Boolean
     "Designates if this is a staff pick campaign."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -833,6 +833,7 @@ const resolvers = {
   },
   CampaignWebsite: {
     affirmation: linkResolver,
+    campaignId: campaign => campaign.legacyCampaignId,
     coverImage: linkResolver,
     showcaseTitle: campaign => campaign.title,
     showcaseDescription: campaign => campaign.callToAction,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -81,20 +81,20 @@ const typeDefs = gql`
   }
 
   type CampaignWebsite implements Showcasable {
-    "The internal-facing title for this campaign."
+    "The internal-facing title for this campaign website."
     internalTitle: String!
-    "The user-facing title for this campaign."
+    "The user-facing title for this campaign website."
     title: String!
-    "The slug for this campaign."
+    "The slug for this campaign website."
     slug: String!
-    "The URL for this campaign."
+    "The URL for this campaign website."
     url: String!
     "The block to display after a user signs up for a campaign."
     affirmation: Block
     "The call to action tagline for this campaign."
     callToAction: String!
-     "The totally NOT legacy / actual Rogue campaign ID associated with this campaign website."
-    legacyCampaignId: Int
+     "The campaign ID associated with this campaign website."
+    campaignId: Int
     "The cover image for this campaign."
     coverImage: Asset
      "The scholarship amount associated with this campaign."


### PR DESCRIPTION
### What's this PR do?

This pull request exposes some additional fields on our `campaign` content type in the Phoenix Contentful space that would be very handy for https://github.com/DoSomething/phoenix-next/pull/2078.

I'm not sure how to get `scholarshipDeadline` in though just yet -- when I added it as a `DateTime` and tried it with good ol' [[Test] Teens for Jeans](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/6LQzMvDNQcYQYwso8qSkQ8), I received an error `DateTime cannot represent an invalid date-time-string 2020-04-25T00:00-08:00`

### How should this be reviewed?

Example request:
```
{
  campaignWebsiteByCampaignId(campaignId:"9001") {
    id
    slug
    legacyCampaignId
    scholarshipAmount
  }
}
```

Example response:
```
{
  "data": {
    "campaignWebsiteByCampaignId": {
      "id": "6LQzMvDNQcYQYwso8qSkQ8",
      "slug": "test-teens-for-jeans",
      "legacyCampaignId": 9001,
      "scholarshipAmount": 20000
    }
  },
```

### Any background context you want to provide?

A nice to have would be to add a computed `campaignId` field to avoid using `legacyCampaignId` in the Phoenix codebase. Felt kind of too hacky to add it into the `transformItem` logic... but maybe it'd be worth it to remove all traces of the `legacyCampaignId` field name.

### Relevant tickets

https://github.com/DoSomething/phoenix-next/pull/2078

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
