### PR TITLE
Adds CampaignWebsite.scholarshipDeadline

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -94,11 +94,13 @@ const typeDefs = gql`
     "The call to action tagline for this campaign."
     callToAction: String!
      "The campaign ID associated with this campaign website."
-    campaignId: Int
+    campaignId: Int!
     "The cover image for this campaign."
     coverImage: Asset
      "The scholarship amount associated with this campaign."
     scholarshipAmount: Int
+     "The scholarship deadline datetime string associated with this campaign."
+    scholarshipDeadline: String
     "The showcase title (the title field.)"
     staffPick: Boolean
     "Designates if this is a staff pick campaign."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `scholarshipDeadline` field to `CampaignWebsite` as a string, after trying to add it as a `DateTime` in #218. We're looking to use this field over in https://github.com/DoSomething/phoenix-next/pull/2078 to render a `CampaignInfoBlock` outside of the CampaignPage universe.

### How should this be reviewed?
Example request:
```
{
  campaignWebsiteByCampaignId(campaignId:"9001") {
    id
    campaignId
    scholarshipAmount
    internalTitle
    scholarshipAmount
    scholarshipDeadline
  }
}
```

Example response:
```
  "data": {
    "campaignWebsiteByCampaignId": {
      "id": "6LQzMvDNQcYQYwso8qSkQ8",
      "campaignId": 9001,
      "scholarshipAmount": 20000,
      "internalTitle": "[Test] Teens for Jeans 2017",
      "scholarshipDeadline": "2020-04-25T00:00-08:00"
    }
  },
```


### Any background context you want to provide?

Also makes `campaignId` required (missed this in #218), as it's a required Contentful field.

### Relevant tickets

References [Pivotal #172439286](https://www.pivotaltracker.com/story/show/172439286).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
