### PR TITLE
Adds additional content to the CampaignWebsite Schema

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -151,6 +151,8 @@ const typeDefs = gql`
     showcaseDescription: String!
     "The showcase image (the coverImage field.)"
     showcaseImage: Asset
+    "Any custom overrides for this cause page."
+    additionalContent: JSON
     ${entryFields}
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds the additional content JSON to the CampaignWebsite schema so we can get the numberofScholarships for campaigns!

### How should this be reviewed?

👀 

### Any background context you want to provide?

Supports the OVRD beta page, where we need to display the scholarship modal and the number of scholarships being offered for Voter reg!

### Relevant tickets

References [Pivotal # 172439286](https://www.pivotaltracker.com/story/show/172439286).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
