### PR TITLE
If no quantity return `null` for `impact`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
   # Install dependencies, run tests, and compile for Lambda.
   build:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:lts
     steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-
       - run: npm install
       - save_cache:
           paths:
@@ -45,8 +45,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-
       - run: npm install
       - run:
           name: publish schema to apollo engine

--- a/package-lock.json
+++ b/package-lock.json
@@ -8639,9 +8639,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-check": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compile": "babel src -d lib/src && babel config -d lib/config"
   },
   "engines": {
-    "node": "8.x",
+    "node": "12.x",
     "npm": "5.3.x"
   },
   "babel": {
@@ -25,7 +25,8 @@
   },
   "prettier": {
     "singleQuote": true,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "arrowParens": "avoid"
   },
   "repository": {
     "type": "git",
@@ -83,7 +84,7 @@
     "fetch-mock": "^8.0.0",
     "jest": "^24.9.0",
     "nodemon": "^2.0.0",
-    "prettier": "1.19.1",
+    "prettier": "2.0.5",
     "prettier-check": "^2.0.0"
   }
 }

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -457,7 +457,7 @@ export const deletePost = async (postId, context) => {
  * @param {Number} id
  * @return {String}
  */
-export const getPermalinkBySignupId = id => `${ROGUE_URL}/signups/${id}`;
+export const getPermalinkBySignupId = (id) => `${ROGUE_URL}/signups/${id}`;
 
 /**
  * Get Rogue post permalink by ID.
@@ -465,7 +465,7 @@ export const getPermalinkBySignupId = id => `${ROGUE_URL}/signups/${id}`;
  * @param {Number} id
  * @return {String}
  */
-export const getPermalinkByPostId = id => `${ROGUE_URL}/posts/${id}`;
+export const getPermalinkByPostId = (id) => `${ROGUE_URL}/posts/${id}`;
 
 /**
  * Create an impact statement from quantity, noun and verb
@@ -591,7 +591,7 @@ export const getSignupsById = async (ids, options) => {
   const signups = transformCollection(json);
 
   // Return signups in the same format requested. <https://git.io/fjLrM>
-  return ids.map(id => find(signups, ['id', id], null));
+  return ids.map((id) => find(signups, ['id', id], null));
 };
 
 /**
@@ -769,7 +769,7 @@ export const getPostsCount = async (args, context) => {
  *
  * @param {Object} campaign
  */
-export const parseCampaignCauses = campaign => {
+export const parseCampaignCauses = (campaign) => {
   // These are provided as two separate ordered arrays
   // from Rogue's Campaigns API. We'll zip them together.
   const { cause, causeNames } = campaign;

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -457,7 +457,7 @@ export const deletePost = async (postId, context) => {
  * @param {Number} id
  * @return {String}
  */
-export const getPermalinkBySignupId = (id) => `${ROGUE_URL}/signups/${id}`;
+export const getPermalinkBySignupId = id => `${ROGUE_URL}/signups/${id}`;
 
 /**
  * Get Rogue post permalink by ID.
@@ -465,7 +465,7 @@ export const getPermalinkBySignupId = (id) => `${ROGUE_URL}/signups/${id}`;
  * @param {Number} id
  * @return {String}
  */
-export const getPermalinkByPostId = (id) => `${ROGUE_URL}/posts/${id}`;
+export const getPermalinkByPostId = id => `${ROGUE_URL}/posts/${id}`;
 
 /**
  * Create an impact statement from quantity, noun and verb
@@ -473,7 +473,7 @@ export const getPermalinkByPostId = (id) => `${ROGUE_URL}/posts/${id}`;
  * @param {Object} post
  * @return {String}
  */
-export const makeImpactStatement = (post) => {
+export const makeImpactStatement = post => {
   if (!post.quantity) {
     return null;
   }
@@ -591,7 +591,7 @@ export const getSignupsById = async (ids, options) => {
   const signups = transformCollection(json);
 
   // Return signups in the same format requested. <https://git.io/fjLrM>
-  return ids.map((id) => find(signups, ['id', id], null));
+  return ids.map(id => find(signups, ['id', id], null));
 };
 
 /**
@@ -769,7 +769,7 @@ export const getPostsCount = async (args, context) => {
  *
  * @param {Object} campaign
  */
-export const parseCampaignCauses = (campaign) => {
+export const parseCampaignCauses = campaign => {
   // These are provided as two separate ordered arrays
   // from Rogue's Campaigns API. We'll zip them together.
   const { cause, causeNames } = campaign;

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -473,7 +473,11 @@ export const getPermalinkByPostId = id => `${ROGUE_URL}/posts/${id}`;
  * @param {Object} post
  * @return {String}
  */
-export const makeImpactStatement = post => {
+export const makeImpactStatement = (post) => {
+  if (!post.quantity) {
+    return null;
+  }
+
   const { noun, verb } = post.actionDetails.data;
   const statement = pluralize(noun, post.quantity, true);
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates what we return for `impact`. This value is generally something like `5 jeans collected`, but in cases where quantity is `0` or `null` we still return `0 jeans collected` or `null jeans collected` but we don't ever want to display that somewhere! Instead, we'll just return `null` so in say Phoenix, we will easily know not to display this information.

### How should this be reviewed?

Will this help us avoid displaying `null` and `0` in our galleries?

### Any background context you want to provide?

Doesn't make sense to show users things like `null jeans collected`! Initially I dealt with this on the Phoenix side (https://github.com/DoSomething/phoenix-next/pull/2036) but we decided to go right to the source.

### Relevant tickets

References [Pivotal #171901122](https://www.pivotaltracker.com/story/show/171901122).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
