### PR TITLE
OEmbed Updates - Log errors & don't cache youtube failures

### DIFF
--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -104,7 +104,7 @@ export const getEmbed = async url => {
     // Avoid caching faulty Youtube embed responses so we can try again in the next request.
     // (https://www.pivotaltracker.com/story/show/171091273/comments/214274074).
     if (
-      new URL(url).hostname.match(/^((www\.)?youtube.com|youtu.be)$/) &&
+      new URL(url).hostname.match(/^((www\.)?youtube\.com|youtu\.be)$/) &&
       !embed.html
     ) {
       return embed;

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -100,6 +100,15 @@ export const getEmbed = async url => {
 
     // Validate and cache the embed for future queries:
     const embed = transformResponse(response, 'version');
+
+    // Avoid caching faulty Youtube embed responses so we can try again in the next request.
+    if (
+      new URL(url).hostname.match(/^((www\.)?youtube.com|youtu.be)$/) &&
+      !embed.html
+    ) {
+      return embed;
+    }
+
     cache.set(url, embed);
 
     return embed;

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -102,6 +102,7 @@ export const getEmbed = async url => {
     const embed = transformResponse(response, 'version');
 
     // Avoid caching faulty Youtube embed responses so we can try again in the next request.
+    // (https://www.pivotaltracker.com/story/show/171091273/comments/214274074).
     if (
       new URL(url).hostname.match(/^((www\.)?youtube.com|youtu.be)$/) &&
       !embed.html

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -39,6 +39,7 @@ const fetchOEmbed = url =>
 
     embedClient.fetch(url, (err, result) => {
       if (err) {
+        logger.warn(`Unable to load OEmbed.`, { url, error: err });
         resolve(null);
       }
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates our embed process to 
- https://github.com/DoSomething/graphql/commit/96a99ca4985b63f2e37f84862259b76c6de9eaec Log a warning when requests via the `oembetter` library fail
- https://github.com/DoSomething/graphql/commit/f213d7e7465e4ff9b5c1d32942554f7f9c064cbd skip the cache if the request is to Youtube and we haven't received HTML in the response (to embed)

### How should this be reviewed?
Is the Regex Ok? Should this be moved to a helper or something? I wasn't sure how else to catch specifically Youtube requests (across the three supported `host`s).

### Any background context you want to provide?
This is part of an investigation effort into mysterious sporadic Youtube embed failures. We generally find that the embeds succeed upon subsequent requests, so we figured we'd skip the cache in these edge cases so it'll at least presumably work on a refresh!

### Relevant tickets

References [Pivotal #171091273](https://www.pivotaltracker.com/story/show/171091273).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
