### PR TITLE
Quick Patch to OEmbed error log

### DIFF
--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -39,7 +39,7 @@ const fetchOEmbed = url =>
 
     embedClient.fetch(url, (err, result) => {
       if (err) {
-        logger.warn(`Unable to load OEmbed.`, { url, error: err });
+        logger.warn(`Unable to load OEmbed.`, { url, error: err.message });
         resolve(null);
       }
 


### PR DESCRIPTION
### What's this PR do?

This pull request patches #226 to log the error _message_ from OEmbed failures.

I was debugging in QA and noticed a rather unhelpful `error="[object, object]"` warning log [in Papertrail](https://my.papertrailapp.com/systems/dosomething-graphql-qa/events?focus=1196925718094422024&selected=1196925718094422024)