### PR TITLE
Update OEmbed helper - Add hard return statements

### DIFF
--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -34,16 +34,16 @@ const supportsOEmbed = url =>
 const fetchOEmbed = url =>
   new Promise(resolve => {
     if (!supportsOEmbed(url)) {
-      resolve(null);
+      return resolve(null);
     }
 
     embedClient.fetch(url, (err, result) => {
       if (err) {
         logger.warn(`Unable to load OEmbed.`, { url, error: err.message });
-        resolve(null);
+        return resolve(null);
       }
 
-      resolve(result);
+      return resolve(result);
     });
   });
 

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -37,7 +37,7 @@ const fetchOEmbed = url =>
       return resolve(null);
     }
 
-    embedClient.fetch(url, (err, result) => {
+    return embedClient.fetch(url, (err, result) => {
       if (err) {
         logger.warn(`Unable to load OEmbed.`, { url, error: err.message });
         return resolve(null);


### PR DESCRIPTION
We seem to always be attempting the OEmbed request whether the URL is whitelisted or not

### What's this PR do?

This pull request adds some `return` statements to the `resolve`s invoked by the `fetchOEmbed` helper to ensure we don't continue running the logic following a Promise resolution.

### How should this be reviewed?
Does this make sense? I don't know if we need that final `return` (wait, the linter seems to require it now.)

### Any background context you want to provide?
While debugging #226 I noticed OEmbed errors (e.g. [this one](https://my.papertrailapp.com/systems/dosomething-graphql/events?focus=1196939335279857694&q=level%3Dwarn&selected=1196939335279857694)) pertaining to URL's not whitelisted within [the config](https://github.com/DoSomething/graphql/blob/eb1260d6e0eeeeaa7aa8333c49ccc829c87bda67/config/embed.js) which should [_not_ be running](https://github.com/DoSomething/graphql/blob/eb1260d6e0eeeeaa7aa8333c49ccc829c87bda67/src/repositories/embed.js#L36-L38) via this fetcher. It seems to be because the logic continues to run even _following_ the `resolve` invocation (presumably because we're not `return`ing).

