### PR TITLE
Removes deprecated SocialDriveBlock.hidePageViews

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -607,8 +607,6 @@ const typeDefs = gql`
   type SocialDriveBlock implements Block {
     "The link for this social drive, with dynamic string tokens."
     link: AbsoluteUrl
-    "Toggles the display of the page views info card adjacent to the block"
-    hidePageViews: Boolean
     ${blockFields}
     ${entryFields}
   }


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `hidePageViews` field from the `SocialDriveBlock` -- it was deprecated in https://github.com/DoSomething/phoenix-next/pull/2108.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🧯 

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
