### PR TITLE
Adds gallery type field and resolver for gallery blocks

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -420,6 +420,14 @@ const typeDefs = gql`
     LEFT
   }
 
+  enum GalleryTypeOption {
+    PERSON
+    CAMPAIGN
+    SCHOLARSHIP
+    PAGE
+    EXTERNAL_LINK
+  }
+
   type GalleryBlock implements Block {
     "Title of the gallery."
     title: String
@@ -427,6 +435,8 @@ const typeDefs = gql`
     itemsPerRow: Int!
     "The alignment of the gallery images relative to their text content."
     imageAlignment: GalleryImageAlignmentOption!
+    "The type of blocks to be rendered in the gallery."
+    galleryType: GalleryTypeOption!
     "Blocks to display or preview in the Gallery."
     blocks: [Showcasable]!
     "Controls the cropping method of the gallery images."
@@ -884,6 +894,7 @@ const resolvers = {
   },
   GalleryBlock: {
     blocks: linkResolver,
+    galleryType: block => stringToEnum(block.galleryType),
     imageAlignment: block => stringToEnum(block.imageAlignment),
     imageFit: block => stringToEnum(block.imageFit),
   },


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new field to the Gallery Block, `galleryType`. This enum is used by the gallery to determine what type of blocks it's children should be.

### How should this be reviewed?

Run locally and test a gallery on dev.

### Any background context you want to provide?

Partner to [this PR](https://github.com/DoSomething/phoenix-next/pull/2142) adding the new field and logic to Phoenix.

### Relevant tickets

References [Pivotal #172203401](https://www.pivotaltracker.com/story/show/172203401).

![Screenshot_2020-05-20 Let's Do This DoSomething org](https://user-images.githubusercontent.com/1865372/82464150-bb327800-9a8b-11ea-9247-ed22bb7f83e3.png)

