### PR TITLE
Filter Signups by referrerUserId

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -500,6 +500,7 @@ export const fetchSignups = async (args, context, additionalQuery) => {
     filter: {
       campaign_id: args.campaignId,
       northstar_id: args.userId,
+      referrer_user_id: args.referrerUserId,
       source: args.source,
     },
     orderBy: args.orderBy,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -479,6 +479,8 @@ const typeDefs = gql`
     signups(
       "The Campaign ID load signups for."
       campaignId: String
+      "The referring User ID to load signups for."
+      referrerUserId: String
       "The signup source to load signups for."
       source: String
       "The user ID to load signups for."
@@ -493,6 +495,8 @@ const typeDefs = gql`
     paginatedSignups(
       "The Campaign ID load signups for."
       campaignId: String
+      "The referring User ID to load signups for."
+      referrerUserId: String
       "The signup source to load signups for."
       source: String
       "The user ID to load signups for."


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to filter Rogue signups by the `referrer_user_id`.

### How should this be reviewed?
Example request:
```
signups(referrerUserId: "5eac795afdce274ba93ec5c3") {
    id 
    userId
    referrerUserId
    campaignId
}
```

Example response:
```
  "data": {
    "signups": [
      {
        "id": 2924,
        "userId": null,
        "referrerUserId": null,
        "campaignId": "9001"
      },
      {
        "id": 2923,
        "userId": null,
        "referrerUserId": null,
        "campaignId": "9000"
      },
      {
        "id": 2922,
        "userId": null,
        "referrerUserId": null,
        "campaignId": "9000"
      }
    ]
  }
```
### Any background context you want to provide?
See #212 for similar reference. This allows us to display referred signups to Alpha referrers in Phoenix.

The `referrer_user_id` is an [indexed, filterable value](https://github.com/DoSomething/rogue/blob/10f2a7d91ab784e82d13c77923ef73c68e5e59da/app/Models/Signup.php#L37-L47) in the Rogue Signups API.

### Relevant tickets

References [Pivotal #172825657](https://www.pivotaltracker.com/story/show/172825657).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
