### PR TITLE
Allow the galleryType field of the Gallery Block to be nullable

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -436,7 +436,7 @@ const typeDefs = gql`
     "The alignment of the gallery images relative to their text content."
     imageAlignment: GalleryImageAlignmentOption!
     "The type of blocks to be rendered in the gallery."
-    galleryType: GalleryTypeOption!
+    galleryType: GalleryTypeOption
     "Blocks to display or preview in the Gallery."
     blocks: [Showcasable]!
     "Controls the cropping method of the gallery images."


### PR DESCRIPTION
### What's this PR do?

This pull request is a quick fix for a gallery block issue where they crash if they query for a null `galleryType`

### How should this be reviewed?

👀 

### Any background context you want to provide?

[Slack convo](https://dosomething.slack.com/archives/CUQMU4Q6B/p1590607150002700)
