### PR TITLE
Adds GroupType and groupTypes query

### DIFF
--- a/src/__tests__/factories.js
+++ b/src/__tests__/factories.js
@@ -18,6 +18,14 @@ factory.define('user', Object, {
   created_at: () => chance.date().toISOString(),
 });
 
+// A group type from Rogue.
+factory.define('group-type', Object, {
+  id: chance.integer({ min: 1, max: 10000 }),
+  name: () => chance.company(),
+  updated_at: () => chance.date().toISOString(),
+  created_at: () => chance.date().toISOString(),
+});
+
 // A post from Rogue. <https://git.io/Je3IA>
 factory.define('post', Object, {
   id: chance.integer({ min: 1, max: 10000 }),

--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -68,6 +68,22 @@ describe('Rogue', () => {
     expect(data.post.impact).toEqual('32 Things Done');
   });
 
+  it('can fetch a group type by ID', async () => {
+    const groupType = await factory('group-type', { id: 7 });
+
+    mock.get(`${ROGUE_URL}/api/v3/group-types/7`, { data: groupType });
+
+    const { data } = await query(gql`
+      {
+        groupType(id: 7) {
+          id
+          name
+        }
+      }
+    `);
+    expect(data.groupType.name).toEqual(groupType.name);
+  });
+
   it('can fetch group types', async () => {
     const groupTypes = await factory('group-type', 3);
 

--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -67,4 +67,21 @@ describe('Rogue', () => {
 
     expect(data.post.impact).toEqual('32 Things Done');
   });
+
+  it('can fetch group types', async () => {
+    const groupTypes = await factory('group-type', 3);
+
+    mock.get(`${ROGUE_URL}/api/v3/group-types`, { data: groupTypes });
+
+    const { data } = await query(gql`
+      {
+        groupTypes {
+          id
+          name
+        }
+      }
+    `);
+
+    expect(data.groupTypes).toHaveLength(3);
+  });
 });

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -788,3 +788,19 @@ export const parseCampaignCauses = campaign => {
 
   return zipWith(cause, causeNames, (id, name) => ({ id, name }));
 };
+
+/**
+ * Get a simple list of group types.
+ *
+ * @return {Array}
+ */
+export const getGroupTypes = async (args, context) => {
+  const response = await fetch(
+    `${ROGUE_URL}/api/v3/group-types`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
+
+  return transformCollection(json);
+};

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -790,6 +790,25 @@ export const parseCampaignCauses = campaign => {
 };
 
 /**
+ * Fetch a group type by ID.
+ *
+ * @param {Number} id
+ * @return {Object}
+ */
+export const getGroupTypeById = async (id, context) => {
+  logger.debug('Loading group type from Rogue', { id });
+
+  const response = await fetch(
+    `${ROGUE_URL}/api/v3/group-types/${id}}`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
+
+  return transformItem(json);
+};
+
+/**
  * Get a simple list of group types.
  *
  * @return {Array}

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -799,7 +799,7 @@ export const getGroupTypeById = async (id, context) => {
   logger.debug('Loading group type from Rogue', { id });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/group-types/${id}}`,
+    `${ROGUE_URL}/api/v3/group-types/${id}`,
     authorizedRequest(context),
   );
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -12,6 +12,7 @@ import {
   getActionById,
   getActionStats,
   getCampaigns,
+  getGroupTypeById,
   getGroupTypes,
   getPaginatedCampaigns,
   getPermalinkBySignupId,
@@ -396,6 +397,8 @@ const typeDefs = gql`
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection
+    "Get a group type by ID."
+    groupType(id: Int!): GroupType
     "Get a list of group types."
     groupTypes: [GroupType]
     "Get a post by ID."
@@ -672,6 +675,7 @@ const resolvers = {
       Loader(context).campaigns.load(args.id, getFields(info)),
     campaigns: (_, args, context, info) =>
       getCampaigns(args, getFields(info), context),
+    groupType: (_, args, context) => getGroupTypeById(args.id, context),
     groupTypes: (_, args, context) => getGroupTypes(args, context),
     paginatedCampaigns: (_, args, context, info) =>
       getPaginatedCampaigns(args, context, info),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -12,6 +12,7 @@ import {
   getActionById,
   getActionStats,
   getCampaigns,
+  getGroupTypes,
   getPaginatedCampaigns,
   getPermalinkBySignupId,
   getPermalinkByPostId,
@@ -185,6 +186,18 @@ const typeDefs = gql`
       "How to order the results (e.g. 'accepted_quantity,desc')."
       orderBy: String = "accepted_quantity,desc"
     ): [SchoolActionStat]
+  }
+
+  "A type of user activity group."
+  type GroupType {
+    "The unique ID for this group type."
+    id: Int!
+    "The name of the group type."
+    name: String!
+    "The time this group type was last modified."
+    updatedAt: DateTime
+    "The time when this group type was originally created."
+    createdAt: DateTime
   }
 
   "A media resource on a post."
@@ -383,6 +396,8 @@ const typeDefs = gql`
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): CampaignCollection
+    "Get a list of group types."
+    groupTypes: [GroupType]
     "Get a post by ID."
     post("The desired post ID." id: Int!): Post
     "Get a list of posts."
@@ -657,6 +672,7 @@ const resolvers = {
       Loader(context).campaigns.load(args.id, getFields(info)),
     campaigns: (_, args, context, info) =>
       getCampaigns(args, getFields(info), context),
+    groupTypes: (_, args, context) => getGroupTypes(args, context),
     paginatedCampaigns: (_, args, context, info) =>
       getPaginatedCampaigns(args, context, info),
     paginatedPosts: (_, args, context, info) =>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `GroupType` type and `groupTypes` query to execute a `GET /api/v3/group-types` request to Rogue per https://github.com/DoSomething/rogue/pull/1026, and a `groupType(id)` query per https://github.com/DoSomething/rogue/pull/1027.


### How should this be reviewed?

👀 

### Any background context you want to provide?

For now, the `groupTypes` query doesn't page through results - which shouldn't be anything we need implement too soon as we're only looking at launching with 1 or maybe 2 or max 5 group types. This query will be used only within the Rogue admin UI.

### Relevant tickets

References [Pivotal #172688197](https://www.pivotaltracker.com/story/show/172688197).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
