### PR TITLE
Adds new voter registration content types

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -736,7 +736,7 @@ const typeDefs = gql`
     description: String
     "If set, the count of current user's approved posts for this action will appear in the sidebar."
     approvedPostCountActionId: Int
-    "Label text for sidebar if the approvedPostCountAction ID is set."
+    "Label text for sidebar if the approvedPostCountActionId is set."
     approvedPostCountLabel: String
     ${blockFields}
     ${entryFields}

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -729,6 +729,26 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type VoterRegistrationDriveBlock implements Block {
+    "The user-facing title for this voter registration drive block."
+    title: String
+    "The user-facing description for this voter registration drive block."
+    description: String
+    "If set, the count of current user's approved posts for this action will appear in the sidebar."
+    approvedPostCountActionId: Int
+    "Label text for sidebar if the approvedPostCountAction ID is set."
+    approvedPostCountLabel: String
+    ${blockFields}
+    ${entryFields}
+  }
+
+  type VoterRegistrationReferralsBlock implements Block {
+    "The user-facing title for this voter registration referrals block."
+    title: String
+    ${blockFields}
+    ${entryFields}
+  }
+
   type AffiliateBlock implements Block {
     "The title for this affiliate."
     title: String!
@@ -800,6 +820,8 @@ const contentTypeMappings = {
   storyPage: 'StoryPageWebsite',
   textSubmissionAction: 'TextSubmissionBlock',
   voterRegistrationAction: 'VoterRegistrationBlock',
+  voterRegistrationDriveAction: 'VoterRegistrationDriveBlock',
+  voterRegistrationReferralsBlock: 'VoterRegistrationReferralsBlock',
 };
 
 /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds new `VoterRegistrationDriveBlock` and `VoterRegistrationReferralsBlock` types to the Phoenix schema, now that I've imported the migrations from https://github.com/DoSomething/phoenix-next/pull/2179 in each of our Phoenix Contentful environments.

### How should this be reviewed?

* `VoterRegistrationDriveBlock` 

Query:
```
{
  block(id:"7un2ZfYO3mrpARy6ZzaUZC") {
    id
    __typename
    ...fields
  }
}

fragment fields on VoterRegistrationDriveBlock {
  title
  description
  approvedPostCountLabel
  approvedPostCountActionId
}

```

Result:
```
{
  "data": {
    "block": {
      "id": "7un2ZfYO3mrpARy6ZzaUZC",
      "__typename": "VoterRegistrationDriveBlock",
      "title": "Share with your friends",
      "description": "Urge your friend to vote based on the causes you care about most. The causes you choose will be mentioned on your custom page.",
      "approvedPostCountLabel": null,
      "approvedPostCountActionId": 27
    }
  },
  ...
```

* `VoterRegistrationReferralsBlock` 

Query:
```
{
  block(id:"5APr82PRUm6WHtHF8cwa7K") {
    id
    __typename
    ...fields
  }
}

fragment fields on VoterRegistrationReferralsBlock {
  title
}
```
Result:

```
{
  "data": {
    "block": {
      "id": "5APr82PRUm6WHtHF8cwa7K",
      "__typename": "VoterRegistrationReferralsBlock",
      "title": "Get 3 friends to register!"
    }
  },
  ...
```

### Any background context you want to provide?

📻 

### Relevant tickets

References [Pivotal #173019820](https://www.pivotaltracker.com/story/show/173019820), [#173019860](https://www.pivotaltracker.com/story/show/173019860)


### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
