### PR TITLE
Add additionalContent field to Phoenix Collection Page

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -331,6 +331,8 @@ const typeDefs = gql`
     affiliates: [AffiliateBlock]
     "The Rich Text content."
     content: JSON!
+    "Any custom overrides for this collection page."
+    additionalContent: JSON
     ${entryFields}
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a JSON `additionalContent` field to the Contentful Phoenix Collection Page schema.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This field was added to the Contentful Content Type in https://github.com/DoSomething/phoenix-next/pull/2191


### Relevant tickets

References [Pivotal #172697820](https://www.pivotaltracker.com/story/show/172697820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
