### PR TITLE
Adds groupId to Signup schema

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -489,6 +489,7 @@ export const makeImpactStatement = post => {
  *
  * @param {String} campaignId
  * @param {Number} count
+ * @param {Number} groupId
  * @param {Number} page
  * @param {String} orderBy
  * @param {String} source
@@ -499,6 +500,7 @@ export const fetchSignups = async (args, context, additionalQuery) => {
   const queryString = stringify({
     filter: {
       campaign_id: args.campaignId,
+      group_id: args.groupId,
       northstar_id: args.userId,
       referrer_user_id: args.referrerUserId,
       source: args.source,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -338,6 +338,8 @@ const typeDefs = gql`
     details: String
     "The user who referred the signup user to create this signup."
     referrerUserId: String
+    "The associated user activity group for this signup."
+    groupId: Int
     "The time this signup was last modified."
     updatedAt: DateTime
     "The time when this signup was originally created."
@@ -519,6 +521,8 @@ const typeDefs = gql`
     signups(
       "The Campaign ID load signups for."
       campaignId: String
+      "The Group ID to load signups for."
+      groupId: Int
       "The referring User ID to load signups for."
       referrerUserId: String
       "The signup source to load signups for."
@@ -535,6 +539,8 @@ const typeDefs = gql`
     paginatedSignups(
       "The Campaign ID load signups for."
       campaignId: String
+      "The Group ID to load signups for."
+      groupId: Int
       "The referring User ID to load signups for."
       referrerUserId: String
       "The signup source to load signups for."


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the ` group_id` field added to the Signups resource in  https://github.com/DoSomething/rogue/pull/1034.

### How should this be reviewed?

Example query:
```
{
  signup(id: 1530) {
    id
    groupId
  }
  signups(groupId: 2) {
    id
    userId
    groupId
  }
}
```

Example response:
```
{
  "data": {
    "signup": {
      "id": 1530,
      "groupId": 2
    },
    "signups": [
      {
        "id": 1530,
        "userId": "5dd8d818fdce276a557e5894",
        "groupId": 2
      }
    ]
  },
  ...
```

### Any background context you want to provide?

Coming soon to a PR near you: adding groupId to Post schema 

### Relevant tickets

References [Pivotal #172541936](https://www.pivotaltracker.com/story/show/172541936).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
