### PR TITLE
Adds groupType field to Group

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -7,6 +7,7 @@ import {
   getActionsByCampaignId,
   getActionById,
   getCampaignById,
+  getGroupTypeById,
   getSignupsById,
 } from './repositories/rogue';
 import { getUserById } from './repositories/northstar';
@@ -98,6 +99,9 @@ export default (context, preview = false) => {
       ),
       gambitAssets: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulAssetById(id, context))),
+      ),
+      groupTypes: new FieldDataLoader((id, fields) =>
+        getGroupTypeById(id, fields, options),
       ),
       homePage: getHomePage(context),
       pages: new DataLoader(ids =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -197,6 +197,8 @@ const typeDefs = gql`
     id: Int!
     "The group type ID this group belongs to."
     groupTypeId: Int!
+    "The group type this group belongs to."
+    groupType: GroupType
     "The group name."
     name: String!
     "The group goal."
@@ -657,6 +659,10 @@ const resolvers = {
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
       getActionStats(args.schoolId, action.id, args.orderBy, context),
+  },
+  Group: {
+    groupType: (group, args, context, info) =>
+      Loader(context).groupTypes.load(group.groupTypeId, getFields(info)),
   },
   Media: {
     url: (media, args) => urlWithQuery(media.url, args),


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `groupType` field on the `Group` field, to return a `GroupType` per https://github.com/DoSomething/graphql/pull/237#discussion_r434631952.

### How should this be reviewed?

Example request:
```
{
  group(id: 4) {
    id
    name
    groupType {
      id
      name
    }
  }
}

```
Example response:
```
{
  "data": {
    "group": {
      "id": 4,
      "name": "Miami",
      "groupType": {
        "id": 1,
        "name": "March For Our Lives"
      }
    }
  },
  ...
```

### Any background context you want to provide?

This will come in handy when we're ready to add a `groupTypeId` to the `Campaign` type in https://www.pivotaltracker.com/story/show/173101101 cc @lindsayrmaher @Dinnall 

### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
