### PR TITLE
Adds groupId and group fields to Post schema

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -7,6 +7,7 @@ import {
   getActionsByCampaignId,
   getActionById,
   getCampaignById,
+  getGroupById,
   getGroupTypeById,
   getSignupsById,
 } from './repositories/rogue';
@@ -99,6 +100,9 @@ export default (context, preview = false) => {
       ),
       gambitAssets: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulAssetById(id, context))),
+      ),
+      groups: new FieldDataLoader((id, fields) =>
+        getGroupById(id, fields, options),
       ),
       groupTypes: new FieldDataLoader((id, fields) =>
         getGroupTypeById(id, fields, options),

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -226,6 +226,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
+      group_id: args.groupId,
       signup_id: args.signupId,
       location: args.location,
       northstar_id: args.userId,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -277,8 +277,10 @@ const typeDefs = gql`
     details: String
     "The user who referred the post user to create this post."
     referrerUserId: String
-    "The associated user activity group for this post."
+    "The associated user activity group ID for this post."
     groupId: Int
+    "The associated user activity group for this post."
+    group: Group
     "The number of items added or removed in this post."
     quantity: Int
     "The human-readable impact (quantity, noun, and verb)."
@@ -342,8 +344,10 @@ const typeDefs = gql`
     details: String
     "The user who referred the signup user to create this signup."
     referrerUserId: String
-    "The associated user activity group for this signup."
+    "The associated user activity group ID for this signup."
     groupId: Int
+    "The associated user activity group for this signup."
+    group: Group
     "The time this signup was last modified."
     updatedAt: DateTime
     "The time when this signup was originally created."
@@ -676,6 +680,10 @@ const resolvers = {
   Post: {
     campaign: (post, args, context, info) =>
       Loader(context).campaigns.load(post.campaignId, getFields(info)),
+    group: (post, args, context, info) =>
+      post.groupId
+        ? Loader(context).groups.load(post.groupId, getFields(info))
+        : null,
     signup: (post, args, context) =>
       Loader(context).signups.load(post.signupId),
     url: (post, args) => urlWithQuery(post.media.url, args),
@@ -704,6 +712,10 @@ const resolvers = {
   Signup: {
     campaign: (signup, args, context, info) =>
       Loader(context).campaigns.load(signup.campaignId, getFields(info)),
+    group: (signup, args, context, info) =>
+      signup.groupId
+        ? Loader(context).groups.load(signup.groupId, getFields(info))
+        : null,
     permalink: signup => getPermalinkBySignupId(signup.id),
     posts: (signup, args, context) => getPostsBySignupId(signup.id, context),
   },

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -277,6 +277,8 @@ const typeDefs = gql`
     details: String
     "The user who referred the post user to create this post."
     referrerUserId: String
+    "The associated user activity group for this post."
+    groupId: Int
     "The number of items added or removed in this post."
     quantity: Int
     "The human-readable impact (quantity, noun, and verb)."
@@ -443,6 +445,8 @@ const typeDefs = gql`
       location: String
       "The referring User ID to load posts for."
       referrerUserId: String
+      "The user activity group ID to load posts for."
+      groupId: Int
       "The post statuses to load posts for."
       status: [ReviewStatus]
       "The post source to load posts for."
@@ -474,6 +478,8 @@ const typeDefs = gql`
       location: String
       "The referring User ID to load posts for."
       referrerUserId: String
+      "The user activity group ID to load posts for."
+      groupId: Int
       "The post statuses to load posts for."
       status: [ReviewStatus]
       "The post source to load posts for."


### PR DESCRIPTION
### What's this PR do?

This pull request supports recent Rogue additions:

* Adds a `groupId` and `group` field to the `Post` type - https://github.com/DoSomething/rogue/pull/1038

* Adds a `groupId` arg for the `posts` and `paginatedPosts` queries - https://github.com/DoSomething/rogue/pull/1040

* Adds a `group` field to the `Signup` type

### How should this be reviewed?

Example request:
```
{
  posts(groupId: 2) {
    id
    status
    type
    group {
      id
      name
      groupTypeId
      groupType {
        id
        name
      }
    }
  }
}
```

Example response:
```
{
  "data": {
    "posts": [
      {
        "id": 1942,
        "status": "REGISTER_OVR",
        "type": "voter-reg",
        "group": {
          "id": 2,
          "name": "San Diego",
          "groupTypeId": 2,
          "groupType": {
            "id": 2,
            "name": "DoSomething Clubs"
          }
        }
      },
      {
        "id": 10,
        "status": "ACCEPTED",
        "type": "photo",
        "group": {
          "id": 2,
          "name": "San Diego",
          "groupTypeId": 2,
          "groupType": {
            "id": 2,
            "name": "DoSomething Clubs"
          }
        }
      }
    ]
  },
  ...
```

### Any background context you want to provide?

🐦 🌴 

### Relevant tickets

References [Pivotal #172541936](https://www.pivotaltracker.com/story/show/172541936).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
