### PR TITLE
Add group type id to campaigns schema and queries

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -139,6 +139,7 @@ export const getCampaignById = async (id, fields, context) => {
  *
  * @param {Number} page
  * @param {Number} count
+ * @param {Number} groupTypeId
  * @return {Array}
  */
 export const fetchCampaigns = async (
@@ -152,6 +153,7 @@ export const fetchCampaigns = async (
       is_open: args.isOpen,
       cause: args.causes ? args.causes.join(',') : undefined,
       has_website: args.hasWebsite,
+      group_type_id: args.groupTypeId,
     },
     isUndefined,
   );

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -116,6 +116,8 @@ const typeDefs = gql`
     startDate: DateTime
     "The time when this campaign last modified."
     updatedAt: DateTime
+    "The group type id associated with this campaign. Only visible to staff/admins."
+    groupTypeId: Int
   }
 
   "Experimental: A paginated list of campaigns. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -116,7 +116,7 @@ const typeDefs = gql`
     startDate: DateTime
     "The time when this campaign last modified."
     updatedAt: DateTime
-    "The group type id associated with this campaign. Only visible to staff/admins."
+    "The group type id associated with this campaign."
     groupTypeId: Int
   }
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -401,7 +401,7 @@ const typeDefs = gql`
       isOpen: Boolean
       "Only return campaigns containing these causes."
       causes: [String]
-      "Only return campaigns containing this groupType id."
+      "Only return campaigns containing this group type id."
       groupTypeId: Int
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
@@ -418,7 +418,7 @@ const typeDefs = gql`
       isOpen: Boolean
       "Only return campaigns containing these causes."
       causes: [String]
-      "Only return campaigns containing this groupType id."
+      "Only return campaigns containing this group type id."
       groupTypeId: Int
       "Only return campaigns that have a contentful campaign associated."
       hasWebsite: Boolean

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -401,6 +401,8 @@ const typeDefs = gql`
       isOpen: Boolean
       "Only return campaigns containing these causes."
       causes: [String]
+      "Only return campaigns containing this groupType id."
+      groupTypeId: Int
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "The number of results per page."
@@ -416,6 +418,8 @@ const typeDefs = gql`
       isOpen: Boolean
       "Only return campaigns containing these causes."
       causes: [String]
+      "Only return campaigns containing this groupType id."
+      groupTypeId: Int
       "Only return campaigns that have a contentful campaign associated."
       hasWebsite: Boolean
       "How to order the results (e.g. 'id,desc')."


### PR DESCRIPTION
### What's this PR do?

This pull request adds a groupTypeId field to the Campaigns schema for rogue, and adds groupTypeId as a filter option for campaigns and paginatedCampaigns.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We want to be able to pull all campaigns related to a certain group type to display in rogue and also want to be able to query for the groupTypeId via a graphql query in phoenix.

### Relevant tickets

References [Pivotal # 173101101](https://www.pivotaltracker.com/story/show/173101101).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
