### PR TITLE
Adds campaign.groupType

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -96,7 +96,7 @@ const typeDefs = gql`
     endDate: DateTime
     "The unique ID for this campaign."
     id: Int!
-    "The contentful campaign id where this campaign is being used."
+    "The Contentful campaign ID where this campaign is being used."
     contentfulCampaignId: String
     "The internal name used to identify the campaign."
     internalTitle: String!
@@ -116,8 +116,10 @@ const typeDefs = gql`
     startDate: DateTime
     "The time when this campaign last modified."
     updatedAt: DateTime
-    "The group type id associated with this campaign."
+    "The user activity group type ID associated with this campaign."
     groupTypeId: Int
+    "The user activity group type associated with this campaign."
+    groupType: GroupType
   }
 
   "Experimental: A paginated list of campaigns. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
@@ -772,6 +774,10 @@ const resolvers = {
     actions: (campaign, args, context) =>
       Loader(context).actionsByCampaignId.load(campaign.id),
     causes: campaign => parseCampaignCauses(campaign),
+    groupType: (campaign, args, context, info) =>
+      campaign.groupTypeId
+        ? Loader(context).groupTypes.load(campaign.groupTypeId, getFields(info))
+        : null,
   },
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `groupType` field to the `Campaign` type, to return the `GroupType` associated with the `groupTypeId` field added in #245. 

### How should this be reviewed?

Example request:
```
{
  campaign(id: 9001) {
    internalTitle
    groupTypeId
    groupType {
      id
      name
    }
  }
}
```

Example response:
```
{
  "data": {
    "campaign": {
      "internalTitle": "Persistent Transitional Installation",
      "groupTypeId": 2,
      "groupType": {
        "id": 2,
        "name": "DoSomething Clubs"
      }
    }
  },
  ...
```

### Any background context you want to provide?

I'm a little confused why we need the `groupTypeId` listed in the fields to return in order to get a valid `groupType` returned. For example, this query doesn't work:
```
{
  campaign(id: 9001) {
    internalTitle
    groupType {
      id
      name
    }
  }
}
```

Response:
```
{
  "data": {
    "campaign": {
      "internalTitle": "Persistent Transitional Installation",
      "groupType": null
    }
  },
  ...
```
### Relevant tickets

References [Pivotal #173101101](https://www.pivotaltracker.com/story/show/173101101).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
