### PR TITLE
Adds paginatedGroups query + groups name filter

### DIFF
--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -86,20 +86,20 @@ describe('Rogue', () => {
   });
 
   it('can fetch groups', async () => {
-    const groups = await factory('group', 13);
+    const groups = await factory('group', 5, { group_type_id: 1 });
 
     mock.get(`${ROGUE_URL}/api/v3/groups/?`, { data: groups });
 
     const { data } = await query(gql`
       {
-        groups {
+        groups(groupTypeId: 1) {
           id
           name
         }
       }
     `);
 
-    expect(data.groups).toHaveLength(13);
+    expect(data.groups).toHaveLength(5);
   });
 
   it('can fetch a group type by ID', async () => {

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -818,13 +818,14 @@ export const getGroupById = async (id, context) => {
  * @param {Number} groupTypeId
  * @return {Array}
  */
-export const fetchGroups = async (args, context, info) => {
+export const fetchGroups = async (args, context, additionalQuery) => {
   const queryString = stringify({
     pagination: 'cursor',
     filter: {
       group_type_id: args.groupTypeId,
       name: args.name,
     },
+    ...additionalQuery,
   });
 
   logger.info('Loading groups from Rogue', { args, queryString });
@@ -856,8 +857,8 @@ export const getGroups = async (args, context) => {
  *
  * @return {Collection}
  */
-export const getPaginatedGroups = async (args, context, info) => {
-  const json = await fetchGroups(args, context, info, {
+export const getPaginatedGroups = async (args, context) => {
+  const json = await fetchGroups(args, context, {
     limit: args.first,
     cursor: {
       after: args.after,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -813,26 +813,58 @@ export const getGroupById = async (id, context) => {
 };
 
 /**
- * Get a simple list of groups.
+ * Fetch groups.
  *
  * @param {Number} groupTypeId
  * @return {Array}
  */
-export const getGroups = async (args, context) => {
+export const fetchGroups = async (args, context, info) => {
   const queryString = stringify({
+    pagination: 'cursor',
     filter: {
       group_type_id: args.groupTypeId,
+      name: args.name,
     },
   });
+
+  logger.info('Loading groups from Rogue', { args, queryString });
 
   const response = await fetch(
     `${ROGUE_URL}/api/v3/groups/?${queryString}`,
     authorizedRequest(context),
   );
 
-  const json = await response.json();
+  return response.json();
+};
+
+/**
+ * Get a simple list of groups.
+ *
+ * @return {Array}
+ */
+export const getGroups = async (args, context) => {
+  const json = await fetchGroups(args, context, {
+    limit: args.count,
+    page: args.page,
+  });
 
   return transformCollection(json);
+};
+
+/**
+ * Fetch a paginated group connection.
+ *
+ * @return {Collection}
+ */
+export const getPaginatedGroups = async (args, context, info) => {
+  const json = await fetchGroups(args, context, info, {
+    limit: args.first,
+    cursor: {
+      after: args.after,
+    },
+  });
+
+  return new Collection(json);
 };
 
 /**

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -813,9 +813,10 @@ export const getGroupById = async (id, context) => {
 };
 
 /**
- * Fetch groups.
+ * Fetch groups from Rogue based on the given filters.
  *
  * @param {Number} groupTypeId
+ * @param {String} name
  * @return {Array}
  */
 export const fetchGroups = async (args, context, additionalQuery) => {

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -451,7 +451,7 @@ const typeDefs = gql`
     "Get a list of groups."
     groups(
       "The group type ID to filter groups by."
-      groupTypeId: Int
+      groupTypeId: Int!
       "The group name to filter groups by."
       name: String
     ): [Group]
@@ -462,7 +462,7 @@ const typeDefs = gql`
       "The cursor to return results after."
       after: String
       "The group type ID to filter groups by."
-      groupTypeId: Int
+      groupTypeId: Int!
       "The group name to filter groups by."
       name: String
     ): GroupCollection

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -17,6 +17,7 @@ import {
   getGroupTypeById,
   getGroupTypes,
   getPaginatedCampaigns,
+  getPaginatedGroups,
   getPermalinkBySignupId,
   getPermalinkByPostId,
   getPosts,
@@ -122,19 +123,19 @@ const typeDefs = gql`
     groupType: GroupType
   }
 
-  "Experimental: A paginated list of campaigns. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
+  "A paginated list of campaigns. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
   type CampaignCollection {
     edges: [CampaignEdge]
     pageInfo: PageInfo!
   }
 
-  "Experimental: Campaign in a paginated list."
+  "Campaign in a paginated list."
   type CampaignEdge {
     cursor: String!
     node: Campaign!
   }
 
-  "Experimental: Information about a paginated list."
+  "Information about a paginated list."
   type PageInfo {
     endCursor: String
     hasNextPage: Boolean!
@@ -211,6 +212,18 @@ const typeDefs = gql`
     updatedAt: DateTime
     "The time when this group was originally created."
     createdAt: DateTime
+  }
+
+  "A paginated list of user activity groups. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
+  type GroupCollection {
+    edges: [GroupEdge]
+    pageInfo: PageInfo!
+  }
+
+  "User activity group in a paginated list."
+  type GroupEdge {
+    cursor: String!
+    node: Group!
   }
 
   "A type of user activity group."
@@ -416,7 +429,7 @@ const typeDefs = gql`
       "The number of results per page."
       count: Int = 20
     ): [Campaign]
-    "Experimental: Get a Relay-style paginated collection of campaigns."
+    "Get a Relay-style paginated collection of campaigns."
     paginatedCampaigns(
       "Get the first N results."
       first: Int = 20
@@ -437,6 +450,17 @@ const typeDefs = gql`
     group(id: Int!): Group
     "Get a list of groups."
     groups("The group type ID to filter groups by." groupTypeId: Int): [Group]
+    "Get a Relay-style paginated collection of groups."
+    paginatedGroups(
+      "Get the first N results."
+      first: Int = 20
+      "The cursor to return results after."
+      after: String
+      "The group type ID to filter groups by."
+      groupTypeId: Int
+      "How to order the results (e.g. 'id,desc')."
+      orderBy: String = "id,desc"
+    ): GroupCollection
     "Get a group type by ID."
     groupType(id: Int!): GroupType
     "Get a list of group types."
@@ -537,7 +561,7 @@ const typeDefs = gql`
     ): [SchoolActionStat]
     "Get a signup by ID."
     signup(id: Int!): Signup
-    "Get a paginated collection of signups."
+    "Get a list of signups."
     signups(
       "The Campaign ID load signups for."
       campaignId: String
@@ -556,6 +580,7 @@ const typeDefs = gql`
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): [Signup]
+    "Get a paginated collection of signups."
     paginatedSignups(
       "The Campaign ID load signups for."
       campaignId: String
@@ -741,6 +766,8 @@ const resolvers = {
     groupTypes: (_, args, context) => getGroupTypes(args, context),
     paginatedCampaigns: (_, args, context, info) =>
       getPaginatedCampaigns(args, context, info),
+    paginatedGroups: (_, args, context, info) =>
+      getPaginatedGroups(args, context, info),
     paginatedPosts: (_, args, context, info) =>
       getPaginatedPosts(args, context, info),
     post: (_, args, context) => getPostById(args.id, context),

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -375,13 +375,13 @@ const typeDefs = gql`
     deleted: Boolean
   }
 
-  "Experimental: A paginated list of signups. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
+  "A paginated list of signups. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
   type SignupCollection {
     edges: [SignupEdge]
     pageInfo: PageInfo!
   }
 
-  "Experimental: Signup in a paginated list."
+  "Signup in a paginated list."
   type SignupEdge {
     cursor: String!
     node: Signup!
@@ -449,7 +449,12 @@ const typeDefs = gql`
     "Get a group by ID."
     group(id: Int!): Group
     "Get a list of groups."
-    groups("The group type ID to filter groups by." groupTypeId: Int): [Group]
+    groups(
+      "The group type ID to filter groups by."
+      groupTypeId: Int
+      "The group name to filter groups by."
+      name: String
+    ): [Group]
     "Get a Relay-style paginated collection of groups."
     paginatedGroups(
       "Get the first N results."
@@ -458,8 +463,8 @@ const typeDefs = gql`
       after: String
       "The group type ID to filter groups by."
       groupTypeId: Int
-      "How to order the results (e.g. 'id,desc')."
-      orderBy: String = "id,desc"
+      "The group name to filter groups by."
+      name: String
     ): GroupCollection
     "Get a group type by ID."
     groupType(id: Int!): GroupType


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `paginatedGroups` query per cursor support added in https://github.com/DoSomething/rogue/pull/1049, as well as a `name` argument for the  `groups` and `paginatedGroups` queries per https://github.com/DoSomething/rogue/pull/1048.

It also removes the "Experimental" descriptor from various comment descriptions, as we landed on sticking with GraphQL Cursor Connections for pagination per https://github.com/dosomething/rfcs/pull/6.

### How should this be reviewed?

Example request:
```
{
  paginatedGroups(groupTypeId: 1, after: "MTgzLkJhbHRpbW9yZSwgTUQ") {
    pageInfo {
      hasNextPage
      hasPreviousPage
      endCursor
    }
    edges {
      cursor
      node {
        id
        name
      }
    }
  }
}
```

Example response:
```
{
  "data": {
    "paginatedGroups": {
      "pageInfo": {
        "hasNextPage": true,
        "hasPreviousPage": false,
        "endCursor": "NTAuQ2VudHJhbCBWYWxsZXksIEFa"
      },
      "edges": [
        {
          "cursor": "MTg2LkJlcmdlbiBDb3VudHksIE5K",
          "node": {
            "id": 186,
            "name": "Bergen County, NJ"
          }
        },
        {
          "cursor": "MTc5LkJldGhlc2RhLCBNRA==",
          "node": {
            "id": 179,
            "name": "Bethesda, MD"
          }
        },
        {
          "cursor": "MjIzLkJpbmdoYW10b24gVW5pdmVyc2l0eSwgTlk=",
          "node": {
            "id": 223,
            "name": "Binghamton University, NY"
          }
        },
        ...
```


### Any background context you want to provide?

🐦 

### Relevant tickets

References [Pivotal #173275849](https://www.pivotaltracker.com/story/show/173275849).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
