### PR TITLE
Adds city, state, and externalId fields to Group type

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -825,6 +825,7 @@ export const fetchGroups = async (args, context, additionalQuery) => {
     filter: {
       group_type_id: args.groupTypeId,
       name: args.name,
+      state: args.state,
     },
     ...additionalQuery,
   });

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -206,8 +206,14 @@ const typeDefs = gql`
     groupType: GroupType
     "The group name."
     name: String!
+     "The group external ID."
+    externalId: String
     "The group goal."
     goal: Int
+     "The group city."
+    city: String
+     "The group state."
+    state: String
     "The time this group was last modified."
     updatedAt: DateTime
     "The time when this group was originally created."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -206,13 +206,13 @@ const typeDefs = gql`
     groupType: GroupType
     "The group name."
     name: String!
-     "The group external ID."
+    "The group external ID."
     externalId: String
     "The group goal."
     goal: Int
-     "The group city."
+    "The group city."
     city: String
-     "The group state."
+    "The group state."
     state: String
     "The time this group was last modified."
     updatedAt: DateTime

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -460,6 +460,8 @@ const typeDefs = gql`
       groupTypeId: Int!
       "The group name to filter groups by."
       name: String
+      "The group state to filter groups by."
+      state: String
     ): [Group]
     "Get a Relay-style paginated collection of groups."
     paginatedGroups(
@@ -471,6 +473,8 @@ const typeDefs = gql`
       groupTypeId: Int!
       "The group name to filter groups by."
       name: String
+      "The group state to filter groups by."
+      state: String
     ): GroupCollection
     "Get a group type by ID."
     groupType(id: Int!): GroupType


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the `city`, `state`, and `external_id` Group fields/filters added  in https://github.com/DoSomething/rogue/pull/1055.

Example query:

```
{
  paginatedGroups(groupTypeId:2, name:"Ab", state:"NJ") {
    edges {
      node {
        id
        name
        city
        state
        externalId
      }
    }
  }
}
```

Example response:
```
{
  "data": {
    "paginatedGroups": {
      "edges": [
        {
          "node": {
            "id": 37252,
            "name": "Abington Avenue Elementary School",
            "city": "Newark",
            "state": "NJ",
            "externalId": "341134002222"
          }
        },
        {
          "node": {
            "id": 37269,
            "name": "Abraham Lincoln School No.14",
            "city": "Elizabeth",
            "state": "NJ",
            "externalId": "340459005508"
          }
        },
        {
          "node": {
            "id": 38901,
            "name": "Barnstable Academy",
            "city": "Oakland",
            "state": "NJ",
            "externalId": "1933105"
          }
        }
      ]
    }
  },
  ...
```
### How should this be reviewed?

👀 

### Any background context you want to provide?

Some Group Types will require user to select state first before searching for the group name in the Group Finder -- this PR adds the support to filtering groups by state that we'll need to implement in Phoenix.

### Relevant tickets

References [Pivotal #173408737](https://www.pivotaltracker.com/story/show/173408737).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
