### PR TITLE
Adds filterByState to GroupType

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -238,6 +238,8 @@ const typeDefs = gql`
     id: Int!
     "The name of the group type."
     name: String!
+    "Whether group finders for this type should first filter by state before searching by name."
+    filterByState: Boolean
     "The time this group type was last modified."
     updatedAt: DateTime
     "The time when this group type was originally created."


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the `filter_by_state` field added to the Group Type resource in https://github.com/DoSomething/rogue/pull/1057.


Example request:
```
{
  groupTypes {
    id
    name
    filterByState
  }
}
```

Example response:
```
{
  "data": {
    "groupTypes": [
      {
        "id": 4,
        "name": "March For Our Lives",
        "filterByState": false
      },
      {
        "id": 1,
        "name": "National Honor Society",
        "filterByState": true
      },
      {
        "id": 2,
        "name": "National Junior Honor Society",
        "filterByState": true
      },
      {
        "id": 3,
        "name": "National Student Council",
        "filterByState": true
      }
    ]
  },
```


### How should this be reviewed?

👀 

### Any background context you want to provide?

🍶 

### Relevant tickets

References [Pivotal #173231765](https://www.pivotaltracker.com/story/show/173231765).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
