### PR TITLE
Renames Group externalId to schoolId

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -825,6 +825,7 @@ export const fetchGroups = async (args, context, additionalQuery) => {
     filter: {
       group_type_id: args.groupTypeId,
       name: args.name,
+      school_id: args.schoolId,
       state: args.state,
     },
     ...additionalQuery,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -206,8 +206,8 @@ const typeDefs = gql`
     groupType: GroupType
     "The group name."
     name: String!
-    "The group external ID."
-    externalId: String
+    "The group school ID."
+    schoolId: String
     "The group goal."
     goal: Int
     "The group city."
@@ -459,11 +459,13 @@ const typeDefs = gql`
     "Get a list of groups."
     groups(
       "The group type ID to filter groups by."
-      groupTypeId: Int!
+      groupTypeId: Int
       "The group name to filter groups by."
       name: String
       "The group state to filter groups by."
       state: String
+      "The group school ID to filter groups by."
+      schoolId: String
     ): [Group]
     "Get a Relay-style paginated collection of groups."
     paginatedGroups(
@@ -472,11 +474,13 @@ const typeDefs = gql`
       "The cursor to return results after."
       after: String
       "The group type ID to filter groups by."
-      groupTypeId: Int!
+      groupTypeId: Int
       "The group name to filter groups by."
       name: String
       "The group state to filter groups by."
       state: String
+      "The group school ID to filter groups by."
+      schoolId: String
     ): GroupCollection
     "Get a group type by ID."
     groupType(id: Int!): GroupType


### PR DESCRIPTION
### What's this PR do?

This pull request renames the `externalId` to `schoolId` field in our `Group` type per https://github.com/DoSomething/rogue/pull/1059, and also adds a `schoolId` filter to find all groups associated with a school ID.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This should be merged after https://github.com/DoSomething/rogue/pull/1059 has been merged. 

### Relevant tickets

References [Pivotal #173408737](https://www.pivotaltracker.com/story/show/173408737).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
