### PR TITLE
Adds queries to get voter registrations count

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -770,6 +770,45 @@ export const getPostsCount = async (args, context) => {
 };
 
 /**
+ * Fetch number of completed voter-reg posts for given groupId.
+ *
+ * @param {Number} groupId
+ * @return Int
+ */
+export const getVoterRegistrationsCountByGroupId = async (groupId, context) => {
+  return getPostsCount(
+    {
+      groupId,
+      limit: 50,
+      status: ['register-form', 'register-ovr'],
+      type: 'voter-reg',
+    },
+    context,
+  );
+};
+
+/**
+ * Fetch number of completed voter-reg posts for given referrerUserId.
+ *
+ * @param {String} referrerUserId
+ * @return Int
+ */
+export const getVoterRegistrationsCountByReferrerUserId = async (
+  referrerUserId,
+  context,
+) => {
+  return getPostsCount(
+    {
+      referrerUserId,
+      limit: 50,
+      status: ['register-form', 'register-ovr'],
+      type: 'voter-reg',
+    },
+    context,
+  );
+};
+
+/**
  * Parse `Cause` type from a given campaign.
  *
  * @param {Object} campaign

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -30,6 +30,8 @@ import {
   getPaginatedSignups,
   getSignupsByUserId,
   getSignupsCount,
+  getVoterRegistrationsCountByGroupId,
+  getVoterRegistrationsCountByReferrerUserId,
   toggleReaction,
   getPostsCount,
   makeImpactStatement,
@@ -633,7 +635,7 @@ const typeDefs = gql`
     ): [Signup]
     "Find out how many signups a particular user has. Intended for use with badges."
     signupsCount(
-      "The Campaign ID count signups for."
+      "The Campaign ID to count signups for."
       campaignId: String
       "The signup source to count signups for."
       source: String
@@ -666,6 +668,16 @@ const typeDefs = gql`
       tags: String
       "The maximum count to report."
       limit: Int = 20
+    ): Int
+    "Find out how many completed voter registrations a group has."
+    voterRegistrationsCountByGroupId(
+      "The Group ID to count completed voter registrations for."
+      groupId: Int!
+    ): Int
+    "Find out how many completed voter registrations a referring user has."
+    voterRegistrationsCountByReferrerUserId(
+      "The Referrer User ID to count completed voter registrations for."
+      referrerUserId: String!
     ): Int
   }
 
@@ -805,6 +817,10 @@ const resolvers = {
     signupsByUserId: (_, args, context) => getSignupsByUserId(args, context),
     signupsCount: (_, args, context) => getSignupsCount(args, context),
     postsCount: (_, args, context) => getPostsCount(args, context),
+    voterRegistrationsCountByGroupId: (_, args, context) =>
+      getVoterRegistrationsCountByGroupId(args.groupId, context),
+    voterRegistrationsCountByReferrerUserId: (_, args, context) =>
+      getVoterRegistrationsCountByReferrerUserId(args.referrerUserId, context),
   },
   Mutation: {
     toggleReaction: (_, args, context) => toggleReaction(args.postId, context),


### PR DESCRIPTION
### What's this PR do?

This pull request adds helper functions to return a count of how many completed voter registrations a referring user or a group has, which will DRY quite a few GraphQL queries within the Phoenix and Rogue codebase, e.g. [VoterRegistrationReferralsBlock](https://github.com/DoSomething/phoenix-next/blob/1203229eb5f9f72530b1871f6e22acb34cc47ac6/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js#L15-L29), [ShowGroup page](https://github.com/DoSomething/rogue/blob/b5908c374142ef39976148d3f4a7b8f756973b70/resources/assets/pages/ShowGroup.js#L28-L33)

This should also help test different voter registration counts for groups and individual referring users per https://github.com/DoSomething/phoenix-next/pull/2216/files#r441566332.

### How should this be reviewed?

Example query:
```
{ 
  voterRegistrationsCountByGroupId(groupId:98716)
}
```

Example response:
```
{
  "data": {
    "voterRegistrationsCountByGroupId": 2
  },
  ...
```

### Any background context you want to provide?

If we run into performance issues with these queries (which we run on the personal OVRD, soon-to-launch groups OVRD pages), we can begin caching them.

We'll also eventually want to add something like `GET /posts-count` endpoint to Rogue to get a real database count, instead of limiting our `GET /posts` index query to 50 (also done for performance).

### Relevant tickets

References [Pivotal #173044099](https://www.pivotaltracker.com/story/show/173044099).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
