### PR TITLE
Fixes bug in voter registration count queries

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -727,6 +727,7 @@ export const getSignupsCount = async (args, context) => {
  * @param {String} action
  * @param {String} actionIds
  * @param {String} campaignId
+ * @param {Number} groupId
  * @param {Number} limit
  * @param {String} location
  * @param {String} source
@@ -741,6 +742,7 @@ export const getPostsCount = async (args, context) => {
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
+      group_id: args.groupId,
       location: args.location,
       northstar_id: args.userId,
       referrer_user_id: args.referrerUserId,


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in #252 -- the `getPostsCount` function needed to support passing a `groupId` argument in order to return the correct count per group or referring user.🤦‍♂️ 


### How should this be reviewed?

👀 

### Any background context you want to provide?

Per the description in #252, I've been wondering about how to add support getting a DB count of all posts in Rogue. Would it make sense to add a `count` query parameter to `GET /posts` index query to re-use the existing filters? Or just create an entirely new `GET /posts-count` endpoint? I really haven't been able to find many examples or standards of how to do this in Laravel via API request.

### Relevant tickets

References [Pivotal #173044099](https://www.pivotaltracker.com/story/show/173044099).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
