### PR TITLE
Remove Phoenix Contentful Page Sidebar Field

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Ready to dive in to GraphQL? Check out the [offical docs](http://graphql.org) or
 The GraphQL server will figure out the most efficent way to resolve your query by caching resources & [batching requests](https://github.com/facebook/dataloader) to the underlying APIs.
 
 ### Discoverability 🔭
-Easily explore & inspect queries using [GraphiQL](/explore)'s autocomplete & documentatino sidebar, or using [introspection queries](http://graphql.org/learn/introspection/) to ask for more details programmatically.
+Easily explore & inspect queries using [GraphiQL](/explore)'s autocomplete & documentation sidebar, or using [introspection queries](http://graphql.org/learn/introspection/) to ask for more details programmatically.
 
 ### Separation of Concerns 🗺
 __Coming Soon:__ With [schema stiching](https://www.apollographql.com/docs/graphql-tools/schema-stitching.html), each individual API is the "source of truth" for it's own schema & the GraphQL gateway is just responsible for stitching things together (for example, linking users in Northstar to signups in Rogue).

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -277,8 +277,6 @@ const typeDefs = gql`
     authors: [PersonBlock]
     "The content of the page."
     content: String
-    "Sidebar blocks rendered alongside the content on the page."
-    sidebar: [Block]
     "Blocks rendered following the content on the page."
     blocks: [Block]
     "Should we display social share buttons on the bottom of the page?"

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -939,7 +939,6 @@ const resolvers = {
     showcaseImage: (page, _, context, info) =>
       linkResolver(page, _, context, info, 'coverImage'),
     blocks: linkResolver,
-    sidebar: linkResolver,
   },
   PersonBlock: {
     photo: linkResolver,


### PR DESCRIPTION
### What's this PR do?

This pull request removes the Phoenix Contentful Page `sidebar` field which has been deprecated from the application in https://github.com/DoSomething/phoenix-next/pull/2268.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I did

### Relevant tickets

References [Pivotal #173738645](https://www.pivotaltracker.com/story/show/173738645).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
