### PR TITLE
Deprecate ContentBlock subTitle field

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -475,8 +475,6 @@ const typeDefs = gql`
     superTitle: String
     "The user-facing title of the block."
     title: String
-    "A subtitle for the content block."
-    subTitle: String
     "The content for the content block."
     content: String!
     "An optional Image to display next to the content."


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates the Contentful Phoenix ContentBlock `subTItle` field.

### How should this be reviewed?
👀 

### Any background context you want to provide?
https://github.com/DoSomething/phoenix-next/pull/2274

### Relevant tickets

References [Pivotal #173785844](https://www.pivotaltracker.com/story/show/173785844).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
