### PR TITLE
Fixes a couple bugs in the Phoenix schema file.

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -848,7 +848,7 @@ const resolvers = {
       Loader(context, preview).collectionPagesBySlug.load(slug),
     companyPageBySlug: (_, { slug, preview }, context) =>
       Loader(context, preview).companyPagesBySlug.load(slug),
-    homePage: (_, { preview }, context) => Loader(context, preview).homePage,
+    homePage: (_, { preview }, context) => Loader(context, preview).homePage(),
     page: (_, { id, preview }, context) =>
       Loader(context, preview).pages.load(id),
     pageBySlug: (_, { slug, preview }, context) =>

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -959,6 +959,9 @@ const resolvers = {
   ResourceWebsite: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
   },
+  Routable: {
+    __resolveType: routable => get(contentTypeMappings, routable.contentType),
+  },
   SelectionSubmissionBlock: {
     richText: block => block.content,
   },


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug where we needed to define a resolver for the `Routable` field so it knows the `__resolveType` of what to return when part of a query. It resolved (initially unintended pun, but I'll take it!) the following server warning:

```
Type "Routable" is missing a "__resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.
```

It also fixes a small bug with the `homePage` resolver. After fixing a bug in [#247](https://github.com/DoSomething/graphql/pull/247/files#diff-5232188b8887c5e2752c803fd8ead1feR110) where the HomePage loader was running automatically, we wrapped the call in the loader in an anonymous function. However, that then led to the resolver not actually calling the Loader, since it was missing the `()`.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We were seeing errors querying the `homePage` on Local, Dev and QA.

### Relevant tickets

[Related to Pivotal Ticket #172922602](https://www.pivotaltracker.com/story/show/172922602)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
