### PR TITLE
Revert #257 because of Apollo Engine issue.

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -633,7 +633,6 @@ const linkResolvers = {
  * @var GraphQLSchema
  */
 const schema = mergeSchemas({
-  mergeDirectives: true,
   schemas: [
     algoliaSchema,
     embedSchema,


### PR DESCRIPTION
This pull request reverts DoSomething/graphql#257, because it was causing [an issue](https://github.com/DoSomething/graphql/pull/257#issuecomment-659584928) when publishing the schema to Apollo (even though it works fine in practice otherwise):

```
Error: Duplicate directive name(s): deprecated, include, optional, requires, skip
 
    at execute.then (~/project/node_modules/apollo-language-server/lib/engine/index.js:80:23)
 
    at <anonymous>
```

For review: @mendelB @weerd since we're already talking about it! 🙈 