### PR TITLE
Delete post mutation bug fix

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -411,6 +411,10 @@ export const rotatePost = async (postId, degrees, context) => {
 export const deletePost = async (postId, context) => {
   const post = await getPostById(postId, context);
 
+  if (!post) {
+    throw new Error(`Post with ID: ${postId} was not found.`);
+  }
+
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
     method: 'DELETE',
     ...requireAuthorizedRequest(context),


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug with the `deletePost` mutation to ensure it doesn't try to delete a post that is not actually found.

We were seeing errors with the `deletePost` mutation where it seems to return an error because it tries to return an `id` of `null` for a deleted post, and the `id` is a non-nullable field. However, when testing the issue seems to be more specifically if the resolver is passed a post ID for a non-existent post. The `post` variable ends up being `null` but we still continue with the `DELETE` method request and that results in a `response.status` of `404` which we don't check against and thus defaults to a response of `null`.

Using mutation to delete a post and returning field data:

![image](https://user-images.githubusercontent.com/105849/87825771-ba2c8580-c845-11ea-8de6-75b3d69cb2e0.png)

Attempting to delete same post again (which now no longer exists) and thrown error:

![image](https://user-images.githubusercontent.com/105849/87826012-27401b00-c846-11ea-99af-6315b78865a4.png)




### How should this be reviewed?

👀 

### Any background context you want to provide?

I debated if it was best to include a conditional to see if a `post` was found and if not throw an error (the approach I went with), or if we should let it continue and attempt to run the `DELETE` request but then add a check for `response.status === 404` and then throw the error 🤷🏽‍♂️  The former seemed better so it doesn't do a followup request we _know_ is going to fail.

### Relevant tickets

References [Pivotal #173629162](https://www.pivotaltracker.com/story/show/173629162).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
