### PR TITLE
Adds location field to Group and SchoolActionStat types

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -60,29 +60,30 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * Get a simple list of action stats by school and or action ID.
  * @TODO: We'll eventually need to support pagination as more action collect school ID's.
  *
- * @param {String} school_id
  * @param {Number} action_id
+ * @param {String} location
+ * @param {String} school_id
  * @param {String} orderBy
  * @return {Array}
  */
-export const getActionStats = async (schoolId, actionId, orderBy, context) => {
+export const getActionStats = async (args, context) => {
   logger.debug('Loading action-stats from Rogue', {
-    schoolId,
-    actionId,
+    'schoolId': args.schoolId,
+    'actionId': args.actionId,
   });
 
-  const filter = {};
-
-  if (actionId) {
-    filter.action_id = actionId;
-  }
-  if (schoolId) {
-    filter.school_id = schoolId;
-  }
+  const filter = omit(
+    {
+      action_id: args.actionId,
+      location: args.location,
+      school_id: args.schoolId,
+    },
+    isUndefined,
+  );
 
   const queryString = stringify({
     filter,
-    orderBy,
+    orderBy: args.orderBy,
     pagination: 'cursor',
   });
 

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -836,6 +836,7 @@ export const fetchGroups = async (args, context, additionalQuery) => {
     pagination: 'cursor',
     filter: {
       group_type_id: args.groupTypeId,
+      location: args.location,
       name: args.name,
       school_id: args.schoolId,
       state: args.state,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -68,8 +68,8 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  */
 export const getActionStats = async (args, context) => {
   logger.debug('Loading action-stats from Rogue', {
-    'schoolId': args.schoolId,
-    'actionId': args.actionId,
+    schoolId: args.schoolId,
+    actionId: args.actionId,
   });
 
   const filter = omit(

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -214,8 +214,8 @@ const typeDefs = gql`
     goal: Int
     "The group city."
     city: String
-    "The group location."
-    location(format: LocationFormat = ISO_FORMAT): String
+    "The group ISO-3166-2 location."
+    location: String
     "The group state."
     state: String @deprecated(reason: "Use 'location' instead.")
     "The time this group was last modified."
@@ -405,8 +405,8 @@ const typeDefs = gql`
     id: Int!
     "The school ID this stat belongs to"
     schoolId: String!
-    "The school location."
-    location(format: LocationFormat = ISO_FORMAT): String
+    "The school ISO-3166-2 location."
+    location: String
     "The action ID this stat belongs to."
     actionId: Int!
     "The action this stat belongs to."
@@ -470,7 +470,7 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
-      "The group location to filter groups by."
+      "The ISO-3166-2 location to filter groups by (e.g. US-NY)."
       location: String
       "The group state to filter groups by."
       state: String
@@ -487,7 +487,7 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
-      "The group location to filter groups by."
+      "The ISO-3166-2 location to filter groups by (e.g. US-NY)."
       location: String
       "The group state to filter groups by."
       state: String

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -214,6 +214,9 @@ const typeDefs = gql`
     goal: Int
     "The group city."
     city: String
+      @deprecated(reason: "Use 'location' instead.")
+    "The group location."
+    location(format: LocationFormat = ISO_FORMAT): String
     "The group state."
     state: String
     "The time this group was last modified."
@@ -403,6 +406,8 @@ const typeDefs = gql`
     id: Int!
     "The school ID this stat belongs to"
     schoolId: String!
+    "The school location."
+    location(format: LocationFormat = ISO_FORMAT): String
     "The action ID this stat belongs to."
     actionId: Int!
     "The action this stat belongs to."
@@ -466,6 +471,8 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
+      "The group region to filter groups by."
+      location: String
       "The group state to filter groups by."
       state: String
       "The group school ID to filter groups by."
@@ -481,6 +488,8 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
+      "The group region to filter groups by."
+      location: String
       "The group state to filter groups by."
       state: String
       "The group school ID to filter groups by."
@@ -577,9 +586,11 @@ const typeDefs = gql`
       count: Int = 20
     ): [Post]
     schoolActionStats(
-      "The School ID to filter school action stats by."
+      "The School ID to filter action stats by."
       schoolId: String
-      "The Action ID to filter school action stats by."
+      "The school region to filter action stats by."
+      location: String
+      "The Action ID to filter action stats by."
       actionId: Int
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -214,11 +214,10 @@ const typeDefs = gql`
     goal: Int
     "The group city."
     city: String
-      @deprecated(reason: "Use 'location' instead.")
     "The group location."
     location(format: LocationFormat = ISO_FORMAT): String
     "The group state."
-    state: String
+    state: String @deprecated(reason: "Use 'location' instead.")
     "The time this group was last modified."
     updatedAt: DateTime
     "The time when this group was originally created."
@@ -471,7 +470,7 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
-      "The group region to filter groups by."
+      "The group location to filter groups by."
       location: String
       "The group state to filter groups by."
       state: String
@@ -488,7 +487,7 @@ const typeDefs = gql`
       groupTypeId: Int
       "The group name to filter groups by."
       name: String
-      "The group region to filter groups by."
+      "The group location to filter groups by."
       location: String
       "The group state to filter groups by."
       state: String
@@ -588,7 +587,7 @@ const typeDefs = gql`
     schoolActionStats(
       "The School ID to filter action stats by."
       schoolId: String
-      "The school region to filter action stats by."
+      "The school location to filter action stats by."
       location: String
       "The Action ID to filter action stats by."
       actionId: Int

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -587,7 +587,7 @@ const typeDefs = gql`
     schoolActionStats(
       "The School ID to filter action stats by."
       schoolId: String
-      "The school location to filter action stats by."
+      "The ISO-3166-2 school location to filter action stats by (e.g. US-NY)."
       location: String
       "The Action ID to filter action stats by."
       actionId: Int

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -819,8 +819,7 @@ const resolvers = {
       getPostsByCampaignId(args.id, args.page, args.count, context),
     postsByUserId: (_, args, context) =>
       getPostsByUserId(args.id, args.page, args.count, context),
-    schoolActionStats: (_, args, context) =>
-      getActionStats(args.schoolId, args.actionId, args.orderBy, context),
+    schoolActionStats: (_, args, context) => getActionStats(args, context),
     signup: (_, args, context) => Loader(context).signups.load(args.id),
     signups: (_, args, context) => getSignups(args, context),
     paginatedSignups: (_, args, context) => getPaginatedSignups(args, context),


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the `location` fields and filters added to the Group and ActionStat resources in https://github.com/DoSomething/rogue/pull/1082.

Example request:
```
{
  schoolActionStats(location: "US-TX") {
    actionId
    location
    schoolId
    impact
  }
}

```

Example response:
```
{
  "data": {
    "schoolActionStats": [
      {
        "actionId": 11,
        "location": "US-TX",
        "schoolId": "4809500",
        "impact": 8
      }
    ]
  },
  ...
```

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

We'll eventually drop the `state` column from the `groups` table once Rogue and Phoenix are updated to query `location` per the discussions in https://github.com/DoSomething/rogue/pull/1079#issuecomment-666484121

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
