### PR TITLE
Adds paginatedSchoolActionStats query

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -93,9 +93,7 @@ export const fetchActionStats = async (args, context, additionalQuery = {}) => {
     authorizedRequest(context),
   );
 
-  const json = await response.json();
-
-  return transformCollection(json);
+  return response.json();
 };
 
 /**

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -66,7 +66,7 @@ export const getActionsByCampaignId = async (campaignId, context) => {
  * @param {String} orderBy
  * @return {Array}
  */
-export const getActionStats = async (args, context) => {
+export const fetchActionStats = async (args, context, additionalQuery = {}) => {
   logger.debug('Loading action-stats from Rogue', {
     schoolId: args.schoolId,
     actionId: args.actionId,
@@ -85,6 +85,7 @@ export const getActionStats = async (args, context) => {
     filter,
     orderBy: args.orderBy,
     pagination: 'cursor',
+    ...additionalQuery,
   });
 
   const response = await fetch(
@@ -95,6 +96,38 @@ export const getActionStats = async (args, context) => {
   const json = await response.json();
 
   return transformCollection(json);
+};
+
+/**
+ * Get a simple list of action stats.
+ *
+ * @param {Number} page
+ * @param {Number} count
+ * @return {Array}
+ */
+export const getActionStats = async (args, context) => {
+  const json = await fetchActionStats(args, context, {
+    limit: args.count,
+    page: args.page,
+  });
+
+  return transformCollection(json);
+};
+
+/**
+ * Fetch a paginated action stat connection.
+ *
+ * @return {Collection}
+ */
+export const getPaginatedActionStats = async (args, context) => {
+  const json = await fetchActionStats(args, context, {
+    limit: args.first,
+    cursor: {
+      after: args.after,
+    },
+  });
+
+  return new Collection(json);
 };
 
 /**

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -843,7 +843,8 @@ const resolvers = {
       getPaginatedCampaigns(args, context),
     paginatedGroups: (_, args, context) => getPaginatedGroups(args, context),
     paginatedPosts: (_, args, context) => getPaginatedPosts(args, context),
-    paginatedSchoolActionStats: (_, args, context) => getPaginatedActionStats(args, context),
+    paginatedSchoolActionStats: (_, args, context) =>
+      getPaginatedActionStats(args, context),
     post: (_, args, context) => getPostById(args.id, context),
     posts: (_, args, context) => getPosts(args, context),
     postsByCampaignId: (_, args, context) =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -843,7 +843,7 @@ const resolvers = {
       getPaginatedCampaigns(args, context),
     paginatedGroups: (_, args, context) => getPaginatedGroups(args, context),
     paginatedPosts: (_, args, context) => getPaginatedPosts(args, context),
-    paginatedSchoolActionStats: (_, args, context) => getPaginatedPosts(args, context),
+    paginatedSchoolActionStats: (_, args, context) => getPaginatedActionStats(args, context),
     post: (_, args, context) => getPostById(args.id, context),
     posts: (_, args, context) => getPosts(args, context),
     postsByCampaignId: (_, args, context) =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -16,6 +16,7 @@ import {
   getGroups,
   getGroupTypeById,
   getGroupTypes,
+  getPaginatedActionStats,
   getPaginatedCampaigns,
   getPaginatedGroups,
   getPermalinkBySignupId,
@@ -421,6 +422,18 @@ const typeDefs = gql`
     updatedAt: DateTime
   }
 
+  "A paginated list of school action stats. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
+  type SchoolActionStatCollection {
+    edges: [SchoolActionStatEdge]
+    pageInfo: PageInfo!
+  }
+
+  "School action stat in a paginated list."
+  type SchoolActionStatEdge {
+    cursor: String!
+    node: SchoolActionStat!
+  }
+
   type Query {
     "Get an Action by ID."
     action(id: Int!): Action
@@ -591,9 +604,27 @@ const typeDefs = gql`
       location: String
       "The Action ID to filter action stats by."
       actionId: Int
+      "The page of results to return."
+      page: Int = 1
+      "The number of results per page."
+      count: Int = 20
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
     ): [SchoolActionStat]
+    paginatedSchoolActionStats(
+      "The School ID to filter action stats by."
+      schoolId: String
+      "The ISO-3166-2 school location to filter action stats by (e.g. US-NY)."
+      location: String
+      "The Action ID to filter action stats by."
+      actionId: Int
+      "Get the first N results."
+      first: Int = 20
+      "The cursor to return results after."
+      after: String
+      "How to order the results (e.g. 'id,desc')."
+      orderBy: String = "id,desc"
+    ): SchoolActionStatCollection
     "Get a signup by ID."
     signup(id: Int!): Signup
     "Get a list of signups."
@@ -812,6 +843,7 @@ const resolvers = {
       getPaginatedCampaigns(args, context),
     paginatedGroups: (_, args, context) => getPaginatedGroups(args, context),
     paginatedPosts: (_, args, context) => getPaginatedPosts(args, context),
+    paginatedSchoolActionStats: (_, args, context) => getPaginatedPosts(args, context),
     post: (_, args, context) => getPostById(args.id, context),
     posts: (_, args, context) => getPosts(args, context),
     postsByCampaignId: (_, args, context) =>


### PR DESCRIPTION
### What's this PR do?

This pull request adds GraphQL support for the cursor pagination added to a `GET /action-stats` index query in Rogue per https://github.com/DoSomething/rogue/pull/1083

### How should this be reviewed?

Example request:
```
{
  paginatedSchoolActionStats {
    edges {
      cursor
      node {
        id
        actionId
        action {
          name
        }
        schoolId
        school {
          id
          name
        }
      }
    }

    pageInfo {
      hasNextPage
    }
  }
}

```

Example response:

```
{
  "data": {
    "paginatedSchoolActionStats": {
      "edges": [
        {
          "cursor": "NzIuNzI=",
          "node": {
            "id": 72,
            "actionId": 11,
            "action": {
              "name": "Autem Repellat Deserunt"
            },
            "schoolId": "4809500",
            "school": {
              "id": "4809500",
              "name": "A & M Consolidated Middle School"
            }
          }
        },
        {
          "cursor": "NzEuNzE=",
          "node": {
            "id": 71,
            "actionId": 82,
            "action": {
              "name": "Et Nobis Cumque"
            },
            "schoolId": "3401457",
            "school": {
              "id": "3401457",
              "name": "Ocean Center Vocational School"
            }
          }
        },
       ...
```

### Any background context you want to provide?

🐍 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
