### PR TITLE
Adds ActionStatsBlock type to Phoenix

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -175,6 +175,13 @@ const typeDefs = gql`
     TRANSPARENT
   }
 
+  type ActionStatsBlock implements Block {
+    "The action ID to display a leaderboard for."
+    actionId: Int!
+    ${blockFields}
+    ${entryFields}
+  }
+
   type AffirmationBlock implements Block {
     "The title displayed on this card."
     header: String
@@ -787,6 +794,7 @@ const typeDefs = gql`
  * @var {Object}
  */
 const contentTypeMappings = {
+  actionStatsBlock: 'ActionStatsBlock',
   affiliates: 'AffiliateBlock',
   affirmation: 'AffirmationBlock',
   callToAction: 'CallToActionBlock',


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for the `actionStatsBlock` content type added in https://github.com/DoSomething/phoenix-next/pull/2312.

### How should this be reviewed?

Example request:

```
{
  block(id: "51SWUaRvyhsJsTWHRGGfjK") {
    internalTitle
    ...ActionStatsBlockFields
  }
}
fragment ActionStatsBlockFields on ActionStatsBlock {
  actionId
}
```

Example response:

```
{
  "data": {
    "block": {
      "internalTitle": "Test Groups Campaign Leaderboard",
      "actionId": 11
    }
  },
  ...
```
### Any background context you want to provide?

🐿️ 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
