### PR TITLE
Adds School location field/filter

### DIFF
--- a/src/repositories/schools.js
+++ b/src/repositories/schools.js
@@ -91,12 +91,13 @@ export const getSchoolById = async id => {
  * @param {String} searchString
  * @return {Object}
  */
-export const searchSchools = async (args) => {
+export const searchSchools = async args => {
   logger.debug('Searching schools', args);
 
   const db = await connectToDatabase();
 
-  const locationFilter = args.state || (args.location ? args.location.substring(3) : null);
+  const locationFilter =
+    args.state || (args.location ? args.location.substring(3) : null);
 
   const res = await db
     .find({
@@ -105,7 +106,7 @@ export const searchSchools = async (args) => {
       name: {
         $regex: args.name,
         $options: 'i',
-      }
+      },
     })
     .limit(20)
     .toArray();

--- a/src/repositories/schools.js
+++ b/src/repositories/schools.js
@@ -85,8 +85,9 @@ export const getSchoolById = async id => {
 };
 
 /**
- * Fetch schools by name for given state.
+ * Fetch schools by name for given location.
  *
+ * @param {String} location
  * @param {String} state
  * @param {String} searchString
  * @return {Object}
@@ -96,6 +97,7 @@ export const searchSchools = async args => {
 
   const db = await connectToDatabase();
 
+  // We'll eventually deprecate the state arg once Phoenix no longer uses it.
   const locationFilter =
     args.state || (args.location ? args.location.substring(3) : null);
 

--- a/src/repositories/schools.js
+++ b/src/repositories/schools.js
@@ -91,19 +91,21 @@ export const getSchoolById = async id => {
  * @param {String} searchString
  * @return {Object}
  */
-export const searchSchools = async (state, searchString) => {
-  logger.debug('Searching schools', { state, searchString });
+export const searchSchools = async (args) => {
+  logger.debug('Searching schools', args);
 
   const db = await connectToDatabase();
+
+  const locationFilter = args.state || (args.location ? args.location.substring(3) : null);
 
   const res = await db
     .find({
       entity: 'school',
-      state,
+      state: locationFilter,
       name: {
-        $regex: searchString,
+        $regex: args.name,
         $options: 'i',
-      },
+      }
     })
     .limit(20)
     .toArray();

--- a/src/resolvers/schools.js
+++ b/src/resolvers/schools.js
@@ -12,7 +12,7 @@ const resolvers = {
   },
   School: {
     location: school => `US-${school.state}`,
-  }
+  },
 };
 
 export default resolvers;

--- a/src/resolvers/schools.js
+++ b/src/resolvers/schools.js
@@ -8,8 +8,11 @@ import { getSchoolById, searchSchools } from '../repositories/schools';
 const resolvers = {
   Query: {
     school: (_, args) => getSchoolById(args.id),
-    searchSchools: (_, args) => searchSchools(args.state, args.name),
+    searchSchools: (_, args) => searchSchools(args),
   },
+  School: {
+    location: school => `US-${school.state}`,
+  }
 };
 
 export default resolvers;

--- a/src/schema/schools.js
+++ b/src/schema/schools.js
@@ -17,8 +17,10 @@ const typeDefs = gql`
     name: String
     "The school city."
     city: String
+    "The school ISO-3166-2 location."
+    location: String
     "The school state."
-    state: String
+    state: String @deprecated(reason: "Use 'location' instead.")
   }
 
   type Query {
@@ -26,8 +28,10 @@ const typeDefs = gql`
     school(id: String!): School
     "Search schools by state and name."
     searchSchools(
+      "The school ISO-3166-2 location to filter by (e.g. US-NY)."
+      location: String
       "The school state to filter by."
-      state: String!
+      state: String
       "The school name to search for."
       name: String!
     ): [School]


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `location` calculated field to the `School` type, to eventually remove the `state` field to keep consistent with other types (refs https://github.com/DoSomething/rogue/pull/1079#issuecomment-666484121).

It keeps support for the `state` argument in `searchSchools`, currently in use by the Phoenix `SchoolFinder` component, and adds support for a new `location` argument which we'll use in the Phoenix `ActionStatsBlock` to display stats for a specific school.

Example request by `location`:
```
{ 
  searchSchools(location: "US-NY", name: "New") {
    id
    name
    location
  }
}
```
Example request by `state`:
```
{
  searchSchools(state: "NY", name: "New") {
    id
    name
    location
  }
}

```

Example response for both:
```
{
  "data": {
    "searchSchools": [
      {
        "id": "3600011",
        "name": "Pinewood Elementary School",
        "location": "US-NY"
      },
      {
        "id": "3600100",
        "name": "New Scotland Elementary School",
        "location": "US-NY"
      },
      {
     ...
}
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

We don't want to store a calculated location field in the Mongo database, as our import process for schools is currently to import the GreatSchools file as-is, without any processing.

### Relevant tickets

* References [Pivotal #174021616](https://www.pivotaltracker.com/n/projects/2417735/stories/174021616).
* https://github.com/DoSomething/graphql/pull/263

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
