### PR TITLE
Adds title and description as fields for the social drive action block

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -621,6 +621,10 @@ const typeDefs = gql`
   type SocialDriveBlock implements Block {
     "The link for this social drive, with dynamic string tokens."
     link: AbsoluteUrl
+    "The user-facing title for this social drive block."
+    title: String
+    "The user-facing description for this social drive block."
+    description: String
     ${blockFields}
     ${entryFields}
   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds title and description as accessible fields to query for the Social Drive Action. We're adding these so that the social drive action can be more customizable, and specifically for when we use it within the Voter Squad campaign.

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #174263168](https://www.pivotaltracker.com/story/show/174263168).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
