### PR TITLE
Adds SignupReferralsBlock

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -47,6 +47,7 @@ const contentTypeMappings = {
   sectionBlock: 'SectionBlock',
   selectionSubmissionAction: 'SelectionSubmissionBlock',
   shareAction: 'ShareBlock',
+  signupReferralsBlock: 'SignupReferralsBlock',
   sixpackExperiment: 'SixpackExperimentBlock',
   socialDriveAction: 'SocialDriveBlock',
   softEdgeWidgetAction: 'SoftEdgeBlock',

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -717,6 +717,13 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type SignupReferralsBlock implements Block {
+    "The user-facing title for this signup referrals block."
+    title: String
+    ${blockFields}
+    ${entryFields}
+  }
+
   type VoterRegistrationBlock implements Block {
     "The user-facing title for this voter registration block."
     title: String


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for a new `SignupReferralsBlock` content type in Phoenix, to be used for embedding within action pages via https://github.com/DoSomething/phoenix-next/pull/2343.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I'll open a PR in Phoenix with the corresponding Contentful migration for the new `signupReferralsBlock` content type.

### Relevant tickets

References [Pivotal #174263179](https://www.pivotaltracker.com/story/show/174263179).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
