### PR TITLE
Refactors Airtable cache to refresh cache before expires

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -35,10 +35,10 @@ const getClient = driver => {
 };
 
 export default class {
-  constructor(name, expiresIn = ONE_MONTH) {
+  constructor(name, policyOptions = {}) {
     this.name = name;
     this.client = getClient(config('cache.driver'));
-    this.policy = new Policy({ expiresIn }, this.client, 'segment');
+    this.policy = new Policy(policyOptions, this.client, 'segment');
   }
 
   /**

--- a/src/repositories/airtable.js
+++ b/src/repositories/airtable.js
@@ -75,10 +75,7 @@ const fetchVotingInformationRecordsByLocation = async () => {
       const { id, fields } = record;
       const location = `US-${fields.State}`;
 
-      result[location] = assign(
-        { id, location },
-        omit(fields, 'State'),
-      );
+      result[location] = assign({ id, location }, omit(fields, 'State'));
     });
 
     return result;

--- a/src/repositories/airtable.js
+++ b/src/repositories/airtable.js
@@ -90,8 +90,6 @@ const fetchVotingInformationRecordsByLocation = async () => {
 
     throw exception;
   }
-
-  return null;
 };
 
 /**
@@ -104,7 +102,7 @@ const cache = new Cache('airtable', {
   expiresIn: 2 * ONE_MINUTE,
   staleIn: ONE_MINUTE,
   generateFunc: async () => {
-    return await fetchVotingInformationRecordsByLocation();
+    return fetchVotingInformationRecordsByLocation();
   },
   generateTimeout: ONE_MINUTE,
   staleTimeout: ONE_MINUTE / 2,

--- a/src/repositories/airtable.js
+++ b/src/repositories/airtable.js
@@ -100,8 +100,15 @@ const cache = new Cache('airtable', {
   generateFunc: async () => {
     return fetchVotingInformationRecordsByLocation();
   },
-  generateTimeout: ONE_MINUTE,
-  staleTimeout: ONE_MINUTE / 2,
+  /**
+   * Wait 10 seconds for our generateFunc to timeout before throwing an error.
+   * This should be shorter than our Lambda/API Gateway timeout (15 seconds) so that we can handle
+   * this error in code (rather than letting the Lambda itself time out).
+   * @see https://github.com/DoSomething/graphql/pull/278#discussion_r492844464
+   */
+  generateTimeout: 10 * 1000,
+  // Set to minimum to immediately return the stale value here (while continuing to fetch updated value).
+  staleTimeout: 1,
 });
 
 /**

--- a/src/repositories/airtable.js
+++ b/src/repositories/airtable.js
@@ -18,7 +18,7 @@ const authorizedRequest = {
 };
 
 // Cache results to avoid hitting Airtable's limit of 5 API requests per second per base.
-const cache = new Cache('airtable', ONE_MINUTE);
+const cache = new Cache('airtable', { expiresIn: ONE_MINUTE });
 
 /**
  * Returns all Location Voting Information records.

--- a/src/repositories/airtable.js
+++ b/src/repositories/airtable.js
@@ -17,78 +17,98 @@ const authorizedRequest = {
   },
 };
 
-// Cache results to avoid hitting Airtable's limit of 5 API requests per second per base.
-const cache = new Cache('airtable', { expiresIn: ONE_MINUTE });
+/**
+ * Fetches the first page of Location Voting Information records from the Airtable API, and
+ * returns data as an object, indexed by ISO-3166-2 location values.
+ *
+ * Airtable "List Records" endpoints have a default page size of 100 records, so we don't need to
+ * paginate through more results, because we'll have a maximum of 50 records (one per U.S. state).
+ *
+ * @return {Object}
+ */
+const fetchVotingInformationRecordsByLocation = async () => {
+  logger.debug('Fetching LocationVotingInformation records from Airtable');
+
+  try {
+    const url = `${AIRTABLE_URL}/v0/${VOTER_REGISTRATION_BASE_ID}/${encodeURI(
+      'Location GOTV Information',
+    )}`;
+
+    const response = await fetch(url, authorizedRequest);
+
+    const json = await response.json();
+
+    /**
+     * Example Airtable API response:
+     *
+     * "records": [
+     *   {
+     *     "id": "recEI2oHq2Hfw38dt",
+     *     "fields": {
+     *         "State": "AL",
+     *         "Voter Registration Deadline": "10/25",
+     *         "Early Voting Starts": "10/5",
+     *         "Absentee Ballot Request Deadline": "10/21",
+     *         "Absentee Ballot Return Deadline Type": "received by",
+     *         "Early Voting Ends": "10/19"
+     *     },
+     *     "createdTime": "2020-08-26T19:12:46.000Z"
+     *   },
+     *   {
+     *     "id": "recHvL0w0KSew1v74",
+     *     "fields": {
+     *         "State": "CA",
+     *         "Voter Registration Deadline": "10/23",
+     *         "Early Voting Starts": "8/30",
+     *         "Absentee Ballot Request Deadline": "10/14",
+     *         "Absentee Ballot Return Deadline Type": "received by",
+     *         "Early Voting Ends": "9/3",
+     *         "Absentee Ballot Return Deadline": "10/18"
+     *     },
+     *     "createdTime": "2020-08-26T19:12:46.000Z"
+     *   },
+     * ...
+     */
+
+    const recordsByLocation = {};
+
+    json.records.forEach(record => {
+      const { id, fields } = record;
+      const location = `US-${fields.State}`;
+
+      recordsByLocation[location] = assign(
+        { id, location },
+        omit(fields, 'State'),
+      );
+    });
+
+    return JSON.stringify(recordsByLocation);
+  } catch (exception) {
+    logger.warn('Unable to fetch LocationVotingInformation.', {
+      error: exception.message,
+    });
+
+    throw exception;
+  }
+
+  return null;
+};
 
 /**
- * Returns all Location Voting Information records.
+ * Cache Airtable records to avoid hitting API limit of 5 requests per second per base.
+ *
+ * Configure the cache to fetch results from the API before cache expires.
+ * @see https://hapi.dev/module/catbox/api/?v=11.1.1#policy
  */
-const getAllLocationVotingInformationRecords = async () => {
-  return cache.remember('LocationVotingInformation', async () => {
-    try {
-      // Default page size is 100, so we only need one request to fetch info for all 50 states.
-      const url = `${AIRTABLE_URL}/v0/${VOTER_REGISTRATION_BASE_ID}/${encodeURI(
-        'Location GOTV Information',
-      )}`;
-
-      const response = await fetch(url, authorizedRequest);
-
-      const json = await response.json();
-
-      /**
-       * Example Airtable API response:
-       *
-       * "records": [
-       *   {
-       *     "id": "recEI2oHq2Hfw38dt",
-       *     "fields": {
-       *         "State": "AL",
-       *         "Voter Registration Deadline": "10/25",
-       *         "Early Voting Starts": "10/5",
-       *         "Absentee Ballot Request Deadline": "10/21",
-       *         "Absentee Ballot Return Deadline Type": "received by",
-       *         "Early Voting Ends": "10/19"
-       *     },
-       *     "createdTime": "2020-08-26T19:12:46.000Z"
-       *   },
-       *   {
-       *     "id": "recHvL0w0KSew1v74",
-       *     "fields": {
-       *         "State": "CA",
-       *         "Voter Registration Deadline": "10/23",
-       *         "Early Voting Starts": "8/30",
-       *         "Absentee Ballot Request Deadline": "10/14",
-       *         "Absentee Ballot Return Deadline Type": "received by",
-       *         "Early Voting Ends": "9/3",
-       *         "Absentee Ballot Return Deadline": "10/18"
-       *     },
-       *     "createdTime": "2020-08-26T19:12:46.000Z"
-       *   },
-       * ...
-       */
-
-      const recordsByLocation = {};
-
-      json.records.forEach(record => {
-        const { id, fields } = record;
-        const location = `US-${fields.State}`;
-
-        recordsByLocation[location] = assign(
-          { id, location },
-          omit(fields, 'State'),
-        );
-      });
-
-      return JSON.stringify(recordsByLocation);
-    } catch (exception) {
-      logger.warn('Unable to load Airtable Location Voting Information.', {
-        error: exception.message,
-      });
-    }
-
-    return null;
-  });
-};
+const cache = new Cache('airtable', {
+  expiresIn: 2 * ONE_MINUTE,
+  staleIn: ONE_MINUTE,
+  generateFunc: async () => {
+    return await fetchVotingInformationRecordsByLocation();
+  },
+  generateTimeout: ONE_MINUTE,
+  staleTimeout: ONE_MINUTE / 2,
+});
 
 /**
  * Returns a Location Voting Information record for a specific location.
@@ -97,16 +117,20 @@ const getAllLocationVotingInformationRecords = async () => {
  * @return {Object}
  */
 const getVotingInformationByLocation = async location => {
-  logger.debug('Loading Location Voting Information from Airtable', {
+  logger.debug('Checking LocationVotingInformation cache', {
     location,
   });
 
   try {
-    const allRecords = await getAllLocationVotingInformationRecords();
+    /**
+     * This cache key value is arbitrary, as our generateFunc fetches the first page of API results,
+     * regardless of the key value passed.
+     */
+    const data = await cache.get('locationVotingInformationIndex');
 
-    return transformResponse(get(JSON.parse(allRecords), location));
+    return transformResponse(get(JSON.parse(data), location));
   } catch (exception) {
-    logger.warn('Unable to load Airtable Location Voting Information.', {
+    logger.warn('Unable to get LocationVotingInformation.', {
       location,
       error: exception.message,
     });

--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -6,7 +6,7 @@ import config from '../../../config';
 import Loader from '../../loader';
 import Cache, { ONE_MONTH } from '../../cache';
 
-const cache = new Cache('contentful', ONE_MONTH);
+const cache = new Cache('contentful', { expiresIn: ONE_MONTH });
 
 const spaceId = config('services.contentful.gambit.spaceId');
 

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -7,8 +7,8 @@ import config from '../../../config';
 import Loader from '../../loader';
 import Cache, { ONE_MONTH } from '../../cache';
 
-const contentCache = new Cache('contentful', ONE_MONTH);
-const previewCache = new Cache('preview.contentful', ONE_MONTH);
+const contentCache = new Cache('contentful', { expiresIn: ONE_MONTH });
+const previewCache = new Cache('preview.contentful', { expiresIn: ONE_MONTH });
 
 const spaceId = config('services.contentful.phoenix.spaceId');
 

--- a/src/repositories/embed.js
+++ b/src/repositories/embed.js
@@ -11,7 +11,7 @@ import { transformResponse } from './helpers';
 const embedClient = OEmbetter();
 
 // Configure embed cache (for one hour).
-const cache = new Cache('embed', ONE_HOUR);
+const cache = new Cache('embed', { expiresIn: ONE_HOUR });
 
 // Configure custom endpoint mappings. <https://git.io/fjeXT>
 embedClient.endpoints(embedClient.suggestedEndpoints);


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the Airtable cache to use the Catbox Policy's `generateFunc` and `staleIn` options to re-validate the cache before it expires, per @DFurnes's suggestion in [Slack](https://dosomething.slack.com/archives/CUQMU4Q6B/p1600372937016400?thread_ts=1600365197.008800&cid=CUQMU4Q6B). See "background context" section for more info.

It also refactors our cache constructor accordingly to expect an Object parameter of Policy options, instead of only a single `expiresIn` Number parameter.



### How should this be reviewed?

The best way to test this is testing the queries we cache, e.g. Gambit entries, Phoenix / embed entries.

I manually tested continuously requesting the `locationVotingInformation` query to verify that a 2nd API request is only made after a minute, e.g.:
```
{
  locationVotingInformation(location:"US-NY") {
    location
    earlyVotingStarts
    earlyVotingEnds
    voterRegistrationDeadline
    absenteeBallotRequestDeadline
    absenteeBallotReturnDeadline
    absenteeBallotReturnDeadlineType
  }
```

### Any background context you want to provide?

This should hopefully fix the influx of GraphQL errors we saw during last week's SMS broadcast:  
```
Cannot read property 'forEach' of undefined
```

Per Slack thread, my suspicion is that multiple Gambit requests are being made to the Airtable API when the cache expires, causing us to hit the API limit. Because we didn't throw an error if one is caught, it'd make sense that Gambit wouldn't error out but that GraphQL would log the warnings with this exception.

We do want the Gambit request to fail if we're unable to access the Airtable data -- as we wouldn't want to send users broadcast messages with empty tags, e.g. "Early voting starts on and ends on ." vs "Early voting starts on Wed 9/29 and ends on Fri 10/13"

### Relevant tickets

References [Pivotal #174179474](https://www.pivotaltracker.com/story/show/174179474).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
