### PR TITLE
Adds groupTypeId filter to schoolActionStats queries

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -57,12 +57,12 @@ export const getActionsByCampaignId = async (campaignId, context) => {
 };
 
 /**
- * Get a simple list of action stats by school and or action ID.
- * @TODO: We'll eventually need to support pagination as more action collect school ID's.
+ * Get a list of action stats.
  *
- * @param {Number} action_id
+ * @param {Number} actionId
+ * @param {Number} groupTypeId
  * @param {String} location
- * @param {String} school_id
+ * @param {String} schoolId
  * @param {String} orderBy
  * @return {Array}
  */
@@ -70,11 +70,13 @@ export const fetchActionStats = async (args, context, additionalQuery = {}) => {
   logger.debug('Loading action-stats from Rogue', {
     schoolId: args.schoolId,
     actionId: args.actionId,
+    groupTypeId: args.groupTypeId,
   });
 
   const filter = omit(
     {
       action_id: args.actionId,
+      group_type_id: args.groupTypeId,
       location: args.location,
       school_id: args.schoolId,
     },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -166,6 +166,8 @@ const typeDefs = gql`
   type ActionStatsBlock implements Block {
     "The action ID to display a leaderboard for."
     actionId: Int!
+    "The group type ID to filter stats by."
+    groupTypeId: Int
     ${blockFields}
     ${entryFields}
   }

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -214,12 +214,14 @@ const typeDefs = gql`
       location: String
       "The Action ID to filter action stats by."
       actionId: Int
+      "The Group Type ID to filter action stats by."
+      groupTypeId: Int
       "The page of results to return."
       page: Int = 1
       "The number of results per page."
       count: Int = 20
-      "How to order the results (e.g. 'id,desc')."
-      orderBy: String = "id,desc"
+      "How to order the results (e.g. 'impact,desc')."
+      orderBy: String = "impact,desc"
     ): [SchoolActionStat]
     paginatedSchoolActionStats(
       "The School ID to filter action stats by."
@@ -228,12 +230,14 @@ const typeDefs = gql`
       location: String
       "The Action ID to filter action stats by."
       actionId: Int
+      "The Group Type ID to filter action stats by."
+      groupTypeId: Int
       "Get the first N results."
       first: Int = 20
       "The cursor to return results after."
       after: String
       "How to order the results (e.g. 'id,desc')."
-      orderBy: String = "id,desc"
+      orderBy: String = "impact,desc"
     ): SchoolActionStatCollection
     "Get a signup by ID."
     signup(id: Int!): Signup


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `groupTypeId` argument for filtering action stats, per https://github.com/DoSomething/rogue/pull/1123, and a `groupTypeId` field to an `ActionStatsBlock` to be used in Phoenix for setting the filter.


Example `schoolActionStats` query:
```
{ 
  schoolActionStats(groupTypeId:1) {
    id
    actionId
    impact
    schoolId
  }
}
```

Example `ActionStatsBlock` query:
```
{
  block(id:"51SWUaRvyhsJsTWHRGGfjK") {
    ...blockFields
  }
}

fragment blockFields on ActionStatsBlock {
  groupTypeId
  actionId
}
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

I changed the default `orderBy` to query by `impact` instead of `id` -- querying by `id` here will throw an Ambiguous ID column error (detailed in https://github.com/DoSomething/rogue/pull/1123). This could be solved by passing an `orderBy` parameter of `action_stats.id` if we needed to order by ID -- the only place we do this is in Rogue admin for a school page, in order to show the most recently created stats -- but definitely wouldn't be a big deal to change that page by impact by default.


### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
