### PR TITLE
Add Club Pagination

### DIFF
--- a/src/__tests__/factories.js
+++ b/src/__tests__/factories.js
@@ -18,6 +18,13 @@ factory.define('user', Object, {
   created_at: () => chance.date().toISOString(),
 });
 
+factory.define('club', Object, {
+  id: chance.integer({ min: 1, max: 10000 }),
+  name: () => chance.company(),
+  updated_at: () => chance.date().toISOString(),
+  created_at: () => chance.date().toISOString(),
+})
+
 // A group from Rogue.
 factory.define('group', Object, {
   id: chance.integer({ min: 1, max: 10000 }),

--- a/src/__tests__/factories.js
+++ b/src/__tests__/factories.js
@@ -23,7 +23,7 @@ factory.define('club', Object, {
   name: () => chance.company(),
   updated_at: () => chance.date().toISOString(),
   created_at: () => chance.date().toISOString(),
-})
+});
 
 // A group from Rogue.
 factory.define('group', Object, {

--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -68,6 +68,40 @@ describe('Rogue', () => {
     expect(data.post.impact).toEqual('32 Things Done');
   });
 
+  it('can fetch a club by ID', async () => {
+    const club = await factory('club', { id: 71 });
+
+    mock.get(`${ROGUE_URL}/api/v3/clubs/71`, { data: club });
+
+    const { data } = await query(gql`
+      {
+        club(id: 71) {
+          id
+          name
+        }
+      }
+    `);
+
+    expect(data.club.name).toEqual(club.name);
+  });
+
+  it('can fetch clubs', async () => {
+    const clubs = await factory('club', 5);
+
+    mock.get(`${ROGUE_URL}/api/v3/clubs`, { data: clubs });
+
+    const { data } = await query(gql`
+      {
+        clubs {
+          id
+          name
+        }
+      }
+    `);
+
+    expect(data.clubs).toHaveLength(5);
+  });
+
   it('can fetch a group by ID', async () => {
     const group = await factory('group', { id: 71 });
 

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -1011,7 +1011,7 @@ export const getPaginatedClubs = async (args, context) => {
   });
 
   return new Collection(json);
-}
+};
 
 /**
  * Fetch a club from Rogue by ID.

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -115,7 +115,7 @@ export const getActionStats = async (args, context) => {
 };
 
 /**
- * Fetch a paginated action stat connection.
+ * Fetch a paginated action stat collection.
  *
  * @return {Collection}
  */
@@ -202,7 +202,7 @@ export const getCampaigns = async (args, context) => {
 };
 
 /**
- * Fetch a paginated campaign connection.
+ * Fetch a paginated campaign collection.
  *
  * @return {Collection}
  */
@@ -257,7 +257,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
 };
 
 /**
- * Fetch a paginated post connection.
+ * Fetch a paginated post collection.
  *
  * @return {Collection}
  */
@@ -532,7 +532,7 @@ export const fetchSignups = async (args, context, additionalQuery) => {
 };
 
 /**
- * Fetch a paginated signup connection.
+ * Fetch a paginated signup collection.
  *
  * @return {Collection}
  */
@@ -904,7 +904,7 @@ export const getGroups = async (args, context) => {
 };
 
 /**
- * Fetch a paginated group connection.
+ * Fetch a paginated group collection.
  *
  * @return {Collection}
  */

--- a/src/resolvers/rogue.js
+++ b/src/resolvers/rogue.js
@@ -17,6 +17,7 @@ import {
   getGroupTypes,
   getPaginatedActionStats,
   getPaginatedCampaigns,
+  getPaginatedClubs,
   getPaginatedGroups,
   getPermalinkBySignupId,
   getPermalinkByPostId,
@@ -65,6 +66,7 @@ const resolvers = {
     groupTypes: (_, args, context) => getGroupTypes(args, context),
     paginatedCampaigns: (_, args, context) =>
       getPaginatedCampaigns(args, context),
+    paginatedClubs: (_, args, context) => getPaginatedClubs(args, context),
     paginatedGroups: (_, args, context) => getPaginatedGroups(args, context),
     paginatedPosts: (_, args, context) => getPaginatedPosts(args, context),
     paginatedSchoolActionStats: (_, args, context) =>

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -86,7 +86,14 @@ const typeDefs = gql`
       orderBy: String = "id,desc"
     ): CampaignCollection
     "Get a list of clubs."
-    clubs("The club name to filter clubs by." name: String): [Club]
+    clubs(
+      "The club name to filter clubs by."
+      name: String
+      "The page of results to return."
+      page: Int = 1
+      "The number of results per page."
+      count: Int = 20
+    ): [Club]
     "Get a club by ID."
     club(id: Int!): Club
     "Get a group by ID."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -94,6 +94,15 @@ const typeDefs = gql`
       "The number of results per page."
       count: Int = 20
     ): [Club]
+    "Get a Relay-style paginated collection of clubs."
+    paginatedClubs(
+      "Get the first N results."
+      first: Int = 20
+      "The cursor to return results after."
+      after: String
+      "The club name to filter clubs by."
+      name: String
+    ): ClubCollection
     "Get a club by ID."
     club(id: Int!): Club
     "Get a group by ID."
@@ -558,6 +567,17 @@ const typeDefs = gql`
     updatedAt: DateTime
     "The time when this club was originally created."
     createdAt: DateTime
+  }
+
+  "A paginated list of clubs. This is a 'Connection' in Relay's parlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification."
+  type ClubCollection {
+    edges: [ClubEdge]
+    pageInfo: PageInfo!
+  }
+  "a Club in a paginated list."
+  type ClubEdge {
+    cursor: String!
+    node: Club!
   }
 
   "A media resource on a post."


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `paginatedClubs` query per Rogue support in https://github.com/DoSomething/rogue/pull/1135.
It also adds some basic tests for clubs (testing pagination got a little tricky for now), plus missing parameters in the `clubs` query (`count` and `page`).

### How should this be reviewed?
Example query:
```
{
  paginatedClubs(first: 2, after: "MQ==") {
    edges {
      node {
        name
      }
      cursor
    }
  }
 }
```
Response:
```js
{
  "data": {
    "paginatedClubs": {
      "edges": [
        {
          "node": {
            "name": "Test1"
          },
          "cursor": "Mg=="
        },
        {
          "node": {
            "name": "test2"
          },
          "cursor": "Mw=="
        }
      ]
    }
  },
```

### Any background context you want to provide?
This will allow us to build an index page on Rogue.

### Relevant tickets

References [Pivotal #174301487](https://www.pivotaltracker.com/story/show/174301487).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
