### PR TITLE
Showcase-able Collection Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -617,6 +617,19 @@
         "minimist": "^1.2.0"
       }
     },
+    "@contentful/rich-text-plain-text-renderer": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-14.1.1.tgz",
+      "integrity": "sha512-vKJxxs1mi9cdjE/gcnWAha19gzZYPR0AIhBRo1lxu/OXpBtbS8ndAjFoCFgY6l0I7XqeMgPRZ3Lb4jrBieMIMQ==",
+      "requires": {
+        "@contentful/rich-text-types": "^14.1.1"
+      }
+    },
+    "@contentful/rich-text-types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-14.1.1.tgz",
+      "integrity": "sha512-Iow9U3so7V+2AngYLmt42BGtHjHGl+DQpxvXaryJe1X9LPHrQ41pALztJZFzDgajoEswBjOgmI9CFeQ1oUAdJA=="
+    },
     "@dosomething/eslint-config": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@dosomething/eslint-config/-/eslint-config-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cjs": true
   },
   "dependencies": {
+    "@contentful/rich-text-plain-text-renderer": "^14.1.1",
     "algoliasearch": "^4.2.0",
     "apollo": "^2.21.1",
     "apollo-datasource": "^0.7.1",

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -137,6 +137,8 @@ const resolvers = {
     showcaseTitle: collectionPage => `${collectionPage.superTitle} ${collectionPage.title}`,
     showcaseDescription: collectionPage => documentToPlainTextString(collectionPage.description),
     showcaseImage: collectionPage => collectionPage.coverImage,
+    path: collectionPage => `/us/collections/${collectionPage.slug}`,
+    url: collectionPage => `${config('services.phoenix.url')}/us/collections/${collectionPage.slug}`,
   },
   CompanyPage: {
     coverImage: linkResolver,

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -134,11 +134,14 @@ const resolvers = {
   CollectionPage: {
     coverImage: linkResolver,
     affiliates: linkResolver,
-    showcaseTitle: collectionPage => `${collectionPage.superTitle} ${collectionPage.title}`,
-    showcaseDescription: collectionPage => documentToPlainTextString(collectionPage.description),
+    showcaseTitle: collectionPage =>
+      `${collectionPage.superTitle} ${collectionPage.title}`,
+    showcaseDescription: collectionPage =>
+      documentToPlainTextString(collectionPage.description),
     showcaseImage: collectionPage => collectionPage.coverImage,
     path: collectionPage => `/us/collections/${collectionPage.slug}`,
-    url: collectionPage => `${config('services.phoenix.url')}/us/collections/${collectionPage.slug}`,
+    url: collectionPage =>
+      `${config('services.phoenix.url')}/us/collections/${collectionPage.slug}`,
   },
   CompanyPage: {
     coverImage: linkResolver,

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -1,5 +1,5 @@
-import { get, first } from 'lodash';
 import GraphQLJSON from 'graphql-type-json';
+import { get, first, truncate } from 'lodash';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 import { GraphQLDateTime } from 'graphql-iso-date';
 import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
@@ -137,7 +137,9 @@ const resolvers = {
     showcaseTitle: collectionPage =>
       `${collectionPage.superTitle} ${collectionPage.title}`,
     showcaseDescription: collectionPage =>
-      documentToPlainTextString(collectionPage.description),
+      truncate(documentToPlainTextString(collectionPage.description), {
+        length: 125,
+      }),
     showcaseImage: (collectionPage, _, context, info) =>
       linkResolver(collectionPage, _, context, info, 'coverImage'),
     path: collectionPage => `/us/collections/${collectionPage.slug}`,

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -138,7 +138,8 @@ const resolvers = {
       `${collectionPage.superTitle} ${collectionPage.title}`,
     showcaseDescription: collectionPage =>
       documentToPlainTextString(collectionPage.description),
-    showcaseImage: collectionPage => collectionPage.coverImage,
+    showcaseImage: (collectionPage, _, context, info) =>
+      linkResolver(collectionPage, _, context, info, 'coverImage'),
     path: collectionPage => `/us/collections/${collectionPage.slug}`,
     url: collectionPage =>
       `${config('services.phoenix.url')}/us/collections/${collectionPage.slug}`,

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -2,6 +2,7 @@ import { get, first } from 'lodash';
 import GraphQLJSON from 'graphql-type-json';
 import { GraphQLAbsoluteUrl } from 'graphql-url';
 import { GraphQLDateTime } from 'graphql-iso-date';
+import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
 
 import Loader from '../../loader';
 import config from '../../../config';
@@ -133,6 +134,9 @@ const resolvers = {
   CollectionPage: {
     coverImage: linkResolver,
     affiliates: linkResolver,
+    showcaseTitle: collectionPage => `${collectionPage.superTitle} ${collectionPage.title}`,
+    showcaseDescription: collectionPage => documentToPlainTextString(collectionPage.description),
+    showcaseImage: collectionPage => collectionPage.coverImage,
   },
   CompanyPage: {
     coverImage: linkResolver,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -346,8 +346,6 @@ const typeDefs = gql`
     internalTitle: String!
     "The title for the home page."
     title: String!
-    "The subtitle for the home page."
-    subTitle: String
     "Cover image for the home page."
     coverImage: Asset
     "Campaigns (campaign and story page entries) rendered as a list on the home page."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -309,9 +309,13 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type CollectionPage implements Showcasable {
+  type CollectionPage implements Showcasable & Routable {
     "The slug for this collection page."
     slug: String!
+    "The root-relative path to this collection page. Use when linking internally."
+    path: String
+    "The full absolute URL to this collection page. Use when linking cross-domain."
+    url: AbsoluteUrl
     "The cover image for this collection page."
     coverImage: Asset!
     "The supertitle (or title prefix)."

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -309,7 +309,7 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  type CollectionPage {
+  type CollectionPage implements Showcasable {
     "The slug for this collection page."
     slug: String!
     "The cover image for this collection page."
@@ -326,6 +326,12 @@ const typeDefs = gql`
     affiliates: [AffiliateBlock]
     "The Rich Text content."
     content: JSON!
+    "The Showcase title (the superTitle + title field)."
+    showcaseTitle: String!
+    "The Showcase description (the Rich Text description field converted to plain text)."
+    showcaseDescription: String!
+    "The Showcase image (the coverImage field)."
+    showcaseImage: Asset!
     "Any custom overrides for this collection page."
     additionalContent: JSON
     ${entryFields}

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -772,8 +772,8 @@ const typeDefs = gql`
     ${entryFields}
   }
 
-  "A web-based campaign interface, such as the traditional campaign template or story page."
-  union ResourceWebsite = CampaignWebsite | StoryPageWebsite
+  "A web-based campaign interface, such as the traditional campaign template, story page, or collection page."
+  union ResourceWebsite = CampaignWebsite | StoryPageWebsite | CollectionPage
 
   type Query {
     "Get a block by ID."


### PR DESCRIPTION
### What's this PR do?

This pull request implements the `Showcaseable` & `Routable` interfaces & fields on the `CollectionPage` to support 'showcasing' a collection page in e.g. galleries. Add the `CollectionPage` to our `ResourceWebsite` union to allow rendering Collection Pages from the [`Homepage#campaigns` field](https://github.com/DoSomething/graphql/blob/f61977a339f65c37aae201f77ec6833621583981/src/schema/contentful/phoenix.js#L344).

### How should this be reviewed?
👀 I made a few decisions here described in the section below.


### Any background context you want to provide?
This isn't necessarily going to be a widely supported feature, but rather a temporary formalization around the current hacky method we use to showcase Collection Pages on the homepage. (See attached Pivotal story). Pending further formalization per [Pivotal ID#171963036](https://www.pivotaltracker.com/n/projects/2438772/stories/171963036).

This page presented a couple of challenges:
- Unlike the `CampaignWebsite` or `StoryPageWebsite`, there's both a `superTitle` _and_ `title` field. I opted to _combine_ the `superTitle` & `title` as the `showcaseTitle` since one or the other didn't seem to make sense. They seem to be typically programmed in tandem e.g. the [Mental Health collection page](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/6kVCfpjClBT4CrtzPpqowz) or [Fossil Giving Tuesday](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/5dPPPe1GtA8zw5DZGJ3XjE). When they aren't, it at least still seems to _work_ e.g. [COVID collection](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/14SWNrUO9lJcjuqWnmiSjF) or [Racial Justice collection](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/2iV0aOuaW7qNlhSIawUQjR). 

- The `description` field is in Rich Text format which is a no-no for showcaseable gallery nodes. I bumped into [this package](https://github.com/contentful/rich-text/tree/master/packages/rich-text-plain-text-renderer) from Contentful which seemed like a simple workaround. (and https://github.com/DoSomething/graphql/pull/283/commits/82c1e0f0745cdb4a9e5bb480d159be10c876b2a1 truncates this down to the first 100 chars since this field can run pretty long which doesn't look right in the gallery cards)


### Relevant tickets

References [Pivotal #173522205](https://www.pivotaltracker.com/story/show/173522205).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.


**Example request**:
```
{
  collectionPageBySlug(slug: "new-state-of-mind") {
    showcaseTitle
    showcaseDescription
    showcaseImage {
      url
    }
    path
    url
  }
 }
```

**Response**:
```
{
  "data": {
    "collectionPageBySlug": {
      "showcaseTitle": "Do Something About Student Mental Health With New State of Mind",
      "showcaseDescription": "Let’s face it. Whether it’s anxiety over school, relationships, or something else, students could use some mental health s...",
      "showcaseImage": {
        "url": "https://images.ctfassets.net/81iqaqpfd8fy/4JT4Y8HXIaB5n4FVpMTI7p/bbf031a4dcf9656772e375e8ce0bb881/bsc.png?f=center"
      },
      "path": "/us/collections/new-state-of-mind",
      "url": "https://www.dosomething.org/us/collections/new-state-of-mind"
    }
  }
```