### PR TITLE
Add Club ID to Post & Signup Schema

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -643,6 +643,8 @@ const typeDefs = gql`
     details: String
     "The user who referred the post user to create this post."
     referrerUserId: String
+    "The associated user activity club ID for this post."
+    clubId: Int
     "The associated user activity group ID for this post."
     groupId: Int
     "The associated user activity group for this post."
@@ -744,6 +746,8 @@ const typeDefs = gql`
     details: String
     "The user who referred the signup user to create this signup."
     referrerUserId: String
+    "The associated user activity club ID for this signup."
+    clubId: Int
     "The associated user activity group ID for this signup."
     groupId: Int
     "The associated user activity group for this signup."


### PR DESCRIPTION
# What's this PR do?

This pull request adds the `clubId` field to Post & Signup schema per https://github.com/DoSomething/rogue/pull/1120

### How should this be reviewed?
👀 

### Any background context you want to provide?
We'd like to surface this field on Posts & Signup cards on the Rogue website.

### Relevant tickets

References [Pivotal #174934297](https://www.pivotaltracker.com/story/show/174934297).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.


**Example Request**
```
{
  signups(userId: "5f889f765daa41047b5c7153") {
    clubId
  }
  posts(userId: "5f889f765daa41047b5c7153") {
    clubId
  }
 }
```

**Response**
```
{
  "data": {
    "signups": [
      {
        "clubId": 1
      },
      {
        "clubId": 1
      }
    ],
    "posts": [
      {
        "clubId": 1
      }
    ]
  },
```