### PR TITLE
Associated Club Field on Rogue Signup & Post

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -7,6 +7,7 @@ import {
   getActionsByCampaignId,
   getActionById,
   getCampaignById,
+  getClubById,
   getGroupById,
   getGroupTypeById,
   getSignupsById,
@@ -99,6 +100,9 @@ export default (context, preview = false) => {
       ),
       gambitAssets: new DataLoader(ids =>
         Promise.all(ids.map(id => getGambitContentfulAssetById(id, context))),
+      ),
+      clubs: new FieldDataLoader((id, fields) =>
+        getClubById(id, fields, options),
       ),
       groups: new FieldDataLoader((id, fields) =>
         getGroupById(id, fields, options),

--- a/src/resolvers/rogue.js
+++ b/src/resolvers/rogue.js
@@ -138,6 +138,10 @@ const resolvers = {
   Post: {
     campaign: (post, args, context, info) =>
       Loader(context).campaigns.load(post.campaignId, getFields(info)),
+    club: (post, args, context, info) =>
+      post.clubId
+        ? Loader(context).clubs.load(post.clubId, getFields(info))
+        : null,
     group: (post, args, context, info) =>
       post.groupId
         ? Loader(context).groups.load(post.groupId, getFields(info))
@@ -173,6 +177,10 @@ const resolvers = {
   Signup: {
     campaign: (signup, args, context, info) =>
       Loader(context).campaigns.load(signup.campaignId, getFields(info)),
+    club: (signup, args, context, info) =>
+      signup.clubId
+        ? Loader(context).clubs.load(signup.clubId, getFields(info))
+        : null,
     group: (signup, args, context, info) =>
       signup.groupId
         ? Loader(context).groups.load(signup.groupId, getFields(info))

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -645,6 +645,8 @@ const typeDefs = gql`
     referrerUserId: String
     "The associated user activity club ID for this post."
     clubId: Int
+    "The associated user activity club for this post."
+    club: Club
     "The associated user activity group ID for this post."
     groupId: Int
     "The associated user activity group for this post."
@@ -748,6 +750,8 @@ const typeDefs = gql`
     referrerUserId: String
     "The associated user activity club ID for this signup."
     clubId: Int
+    "The associated user activity club for this signup."
+    club: Club
     "The associated user activity group ID for this signup."
     groupId: Int
     "The associated user activity group for this signup."


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #284 to add a `club` field on the Rogue Post & Signup types which will resolve to the associated club resource

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will make it handy to surface the club name alongside any associated posts/signups in Rogue

### Relevant tickets

References [Pivotal #174934297](https://www.pivotaltracker.com/story/show/174934297).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

**Example Request**
```
{
  signups(userId: "5f889f765daa41047b5c7153") {
    clubId
    club {
      name
      leader {
        firstName
      }
    }
  }
  posts(userId: "5f889f765daa41047b5c7153") {
    clubId
    club {
      name
      leader {
        firstName
      }
    }
  }
 }
```

**Response**
```
{
  "data": {
    "signups": [
      {
        "clubId": 1,
        "club": {
          "name": "Test Club 1",
          "leader": {
            "firstName": "Mendel"
          }
        }
      },
      {
        "clubId": 1,
        "club": {
          "name": "Test Club 1",
          "leader": {
            "firstName": "Mendel"
          }
        }
      }
    ],
    "posts": [
      {
        "clubId": 1,
        "club": {
          "name": "Test Club 1",
          "leader": {
            "firstName": "Mendel"
          }
        }
      }
    ]
  },
```
