### PR TITLE
Removes VoterRegistrationDriveAction fields no longer used

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -744,10 +744,6 @@ const typeDefs = gql`
     title: String
     "The user-facing description for this voter registration drive block."
     description: String
-    "If set, the count of current user's approved posts for this action will appear in the sidebar."
-    approvedPostCountActionId: Int
-    "Label text for sidebar if the approvedPostCountActionId is set."
-    approvedPostCountLabel: String
     ${blockFields}
     ${entryFields}
   }


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `approvedPostCountActionId` and `approvedPostCountLabel` fields from the `VoterRegistrationDriveAction` type. They were removed from the Phoenix codebase in https://github.com/DoSomething/phoenix-next/pull/2372.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I'll update the Phoenix content type and migration (and GraphQL schema for tests) upon merging this PR.

### Relevant tickets

References [Pivotal #175277209](https://www.pivotaltracker.com/story/show/175277209).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
