### PR TITLE
Deprecate Embed Block previewImage Field

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -157,9 +157,6 @@ const resolvers = {
     showcaseImage: (person, _, context, info) =>
       linkResolver(person, _, context, info, 'image'),
   },
-  EmbedBlock: {
-    previewImage: linkResolver,
-  },
   GalleryBlock: {
     blocks: linkResolver,
     galleryType: block => stringToEnum(block.galleryType),

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -396,8 +396,6 @@ const typeDefs = gql`
   type EmbedBlock implements Block {
     "The URL of the content to be embedded."
     url: String!
-    "A preview image of the embed content. If set, replaces the embed on smaller screens."
-    previewImage: Asset
     ${blockFields}
     ${entryFields}
   }


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates the `previewImage` field from the Contentful Phoenix `EmbedBlock`.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We don't use this anymore (see [Slack](https://dosomething.slack.com/archives/CP2D7UGAU/p1602883724029000)). Removed from Phoenix in https://github.com/DoSomething/phoenix-next/pull/2403

### Relevant tickets

References [Pivotal #168302139](https://www.pivotaltracker.com/story/show/168302139).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
