### PR TITLE
Update Collection Page Showcase

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -138,7 +138,7 @@ const resolvers = {
       `${collectionPage.superTitle}: ${collectionPage.title}`,
     showcaseDescription: collectionPage =>
       truncate(documentToPlainTextString(collectionPage.description), {
-        length: 125,
+        length: 50,
       }),
     showcaseImage: (collectionPage, _, context, info) =>
       linkResolver(collectionPage, _, context, info, 'coverImage'),

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -135,7 +135,7 @@ const resolvers = {
     coverImage: linkResolver,
     affiliates: linkResolver,
     showcaseTitle: collectionPage =>
-      `${collectionPage.superTitle} ${collectionPage.title}`,
+      `${collectionPage.superTitle}: ${collectionPage.title}`,
     showcaseDescription: collectionPage =>
       truncate(documentToPlainTextString(collectionPage.description), {
         length: 125,


### PR DESCRIPTION
### What's this PR do?

This pull request adds two quick updates to the showcase-able fields of the Collection Page per design QA.

### How should this be reviewed?
👀 

### Any background context you want to provide?
https://www.pivotaltracker.com/story/show/173522205/comments/218945027

### Relevant tickets

References [Pivotal #173522205](https://www.pivotaltracker.com/story/show/173522205).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

**Example Request**:
```
{  
  collectionPageBySlug(slug: "fossil-giving-tuesday") {
    showcaseTitle
    showcaseDescription
  }
}
```

**Response**
```
{
  "data": {
    "collectionPageBySlug": {
      "showcaseTitle": "Do something on giving tuesday with: Fossil",
      "showcaseDescription": "DoSomething.org and Fossil have a shared belief..."
    }
  }
```