### PR TITLE
Phoenix Gallery Block External Link -> Content Block (+ fixes playground CDN)

### DIFF
--- a/src/playground.html
+++ b/src/playground.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
 <html>
-
   <head>
-    <meta charset=utf-8/>
-    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"
+    />
     <title>DoSomething.org GraphQL</title>
-    <link rel="stylesheet" href="https://unpkg.com/graphql-playground-react@^1.7.19/build/static/css/index.css" />
-    <script src="https://unpkg.com/graphql-playground-react@^1.7.19/build/static/js/middleware.js"></script>
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"
+    />
+    <link
+      rel="shortcut icon"
+      href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"
+    />
+    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
   </head>
 
   <body>
@@ -15,8 +24,8 @@
       window.addEventListener('load', function (event) {
         GraphQLPlayground.init(document.getElementById('app'), {
           // options as 'endpoint' belong here
-        })
-      })
+        });
+      });
     </script>
     <script src="https://unpkg.com/environment-badge@^1.1.1/dist/bundle.js"></script>
   </body>

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -159,7 +159,11 @@ const resolvers = {
   },
   GalleryBlock: {
     blocks: linkResolver,
-    galleryType: block => stringToEnum(block.galleryType),
+    galleryType: block =>
+      // @HACK: Manually convert the 'External Link' type to the new 'CONTENT_BLOCK' type until we migrate existing entries.
+      block.galleryType === 'External Link'
+        ? 'CONTENT_BLOCK'
+        : stringToEnum(block.galleryType),
     imageAlignment: block => stringToEnum(block.imageAlignment),
     imageFit: block => stringToEnum(block.imageFit),
   },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -428,7 +428,7 @@ const typeDefs = gql`
     CAMPAIGN
     SCHOLARSHIP
     PAGE
-    EXTERNAL_LINK
+    CONTENT_BLOCK
   }
 
   type GalleryBlock implements Block {


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `GalleryBlock` type's enum list to deprecate the `EXTERNAL_LINK` in favor of the new `CONTENT_BLOCK` type. It also resolves current (unformatted) `External Link` entry values to the `CONTENT_BLOCK` enum for backward compatibility until we update the current entries on Contentful.

Also updates the CDN for loading the `graphql-playground-react` library to run our playground page since the `unpkg` link has been failing to load. The library documentation [notes](https://github.com/graphql/graphql-playground#as-html-page) to use this CDN in their [example](https://github.com/graphql/graphql-playground/blob/ac496f12652be0b0e2f2bcb4ff1dd6a765a904c9/packages/graphql-playground-html/minimal.html#L10). (See Slack thread [here](https://dosomething.slack.com/archives/CUQMU4Q6B/p1603228843013100))

### How should this be reviewed?
👀 

### Any background context you want to provide?
Editors have found the `External Link` type confusing. `Content Block` maps directly to the entry type used here.

Corresponding Phoenix PR impending.

### Relevant tickets

References [Pivotal #174048432](https://www.pivotaltracker.com/story/show/174048432/comments/218819089).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
