### PR TITLE
Remove graphql-playground-react favicon from playground

### DIFF
--- a/src/playground.html
+++ b/src/playground.html
@@ -11,10 +11,6 @@
       rel="stylesheet"
       href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"
     />
-    <link
-      rel="shortcut icon"
-      href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"
-    />
     <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
   </head>
 


### PR DESCRIPTION
### What's this PR do?

This pull request removed the graphql-playground-react library favicon from the playground HTML file I mistakenly included in #291 