### PR TITLE
Retire Gallery Block - galleryType field resolver hack

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -159,11 +159,7 @@ const resolvers = {
   },
   GalleryBlock: {
     blocks: linkResolver,
-    galleryType: block =>
-      // @HACK: Manually convert the 'External Link' type to the new 'CONTENT_BLOCK' type until we migrate existing entries.
-      block.galleryType === 'External Link'
-        ? 'CONTENT_BLOCK'
-        : stringToEnum(block.galleryType),
+    galleryType: block => stringToEnum(block.galleryType),
     imageAlignment: block => stringToEnum(block.imageAlignment),
     imageFit: block => stringToEnum(block.imageFit),
   },


### PR DESCRIPTION
### What's this PR do?

This pull request removes the hack to convert Gallery Blocks with a `galleryType` of `External Link` since we've converted all existing entries on Contentful production.

### How should this be reviewed?
👀 

### Any background context you want to provide?
#291 

### Relevant tickets

References [Pivotal #174048432](https://www.pivotaltracker.com/story/show/174048432).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
