### PR TITLE
Add Causes Facet Filtering for Algolia Campaigns Search

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -79,11 +79,25 @@ class Algolia extends DataSource {
   }
 
   /**
+   * Filter search by campaigns containing these causes (using facet filtering).
+   *
+   * @param {Array} causes
+   * @return {String}
+   */
+  filterCauses(causes) {
+    // e.g. ["environment", "racial-justice"] => "cause:environment OR cause:racial-justice".
+    const causeFacets = causes.map(cause => `cause:${cause}`).join(' OR ');
+
+    return ` AND (${causeFacets})`;
+  }
+
+  /**
    * Search campaigns index
    */
   async searchCampaigns(options = {}) {
     const {
       cursor = '0',
+      causes = [],
       isOpen = true,
       hasScholarship = null,
       perPage = 20,
@@ -102,6 +116,11 @@ class Algolia extends DataSource {
       filters += hasScholarship
         ? this.filterScholarshipCampaigns
         : this.filterNonScholarshipCampaigns;
+    }
+
+    // If specified, append filter for campaign causes.
+    if (causes.length) {
+      filters += this.filterCauses(causes);
     }
 
     const results = await index.search(term, {

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -17,6 +17,8 @@ const typeDefs = gql`
       isOpen: Boolean
       "Search for campaigns that have or do not have a scholarship."
       hasScholarship: Boolean
+      "Filter by campaigns containing these causes."
+      causes: [String]
       "Number of results per page."
       perPage: Int
       "Pagination search cursor for the specified search location."


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `causes` filter to the Algolia `searchCampaigns` Query to allow filtering campaigns by included causes

### How should this be reviewed?
👀 

### Any background context you want to provide?
We're using [Algolia Faceting](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting) to filter by causes.

In terms of the difference between this and our typical filters -- TL;DR from the [attached doc](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/#difference-between-filtering-and-faceting):
> faceting is useful when building a UI, where users can select facets categories to refine their search further.

Which is precisely our intended use case for our Explore Campaigns page on Phoenix:
![image](https://user-images.githubusercontent.com/12417657/98159365-7029e700-1eaa-11eb-9579-ed9278429cce.png)

First step was to configure the `causes` attribute as a Facet via the Algolia UI:
<img width="1552" alt="Screen Shot 2020-11-04 at 2 33 20 PM" src="https://user-images.githubusercontent.com/12417657/98159538-c4cd6200-1eaa-11eb-8b71-4f65638be1e5.png">

(I used the UI dashboard in favor of [the API](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/how-to/declaring-attributes-for-faceting?language=php) since I was a little confused as to how to set this up via our [Laravel Scout](https://laravel.com/docs/7.x/scout#configuring-model-indexes) integration on Rogue. They seem to encourage integrating with their own [Scout Extended](https://www.algolia.com/doc/framework-integration/laravel/getting-started/introduction-to-scout-extended/?language=php) library, but it's still unclear to me what the immediate value of that is, or how to set up the facets programmatically. 

Interestingly, although Algolia provides a dedicated [facetFilters](https://www.algolia.com/doc/api-reference/api-parameters/facetFilters/) attribute, [they recommend](https://www.algolia.com/doc/api-reference/api-parameters/facetFilters/#how-to-use) using the main [`filter` syntax](https://www.algolia.com/doc/api-reference/api-parameters/filters/#facet-filters) which supports facets as well.

### Relevant tickets

References [Pivotal #173817560](https://www.pivotaltracker.com/story/show/173817560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

Example Query:
```
{  
  searchCampaigns(causes: ["income-inequality", "bullying"]) {
    edges {
      node {
        id
        causes {
          name
        }
      }
    }
  }
}
```

Response:
```
"data": {
    "searchCampaigns": {
      "edges": [
        {
          "node": {
            "id": 9991,
            "causes": [
              {
                "name": "Addiction"
              },
              {
                "name": "Bullying"
              },
              {
                "name": "Environment"
              },
              {
                "name": "Other"
              }
            ]
          }
        },
        {
          "node": {
            "id": 9985,
            "causes": [
              {
                "name": "Criminal Justice"
              },
              {
                "name": "Discrimination"
              },
              {
                "name": "Income Inequality"
              },
              {
                "name": "Racial Justice/Racial Equity"
              },
              {
                "name": "Other"
              }
            ]
          }
        },
        {
          "node": {
            "id": 9979,
            "causes": [
              {
                "name": "Bullying"
              },
              {
                "name": "Mental Health"
              },
              {
                "name": "Relationship"
              },
              {
                "name": "Week of Action"
              }
            ]
          }
        }
...
```