### PR TITLE
Rename 'AbsoluteUrl' scalar to URL.

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -65,7 +65,7 @@ const contentTypeMappings = {
 const resolvers = {
   JSON: JSONResolver,
   DateTime: DateTimeResolver,
-  AbsoluteUrl: URLResolver,
+  URL: URLResolver,
   Query: {
     block: (_, { id, preview }, context) =>
       Loader(context, preview).blocks.load(id),

--- a/src/resolvers/embed.js
+++ b/src/resolvers/embed.js
@@ -9,7 +9,7 @@ import { stringToEnum } from './helpers';
  * @var {Object}
  */
 const resolvers = {
-  AbsoluteUrl: URLResolver,
+  URL: URLResolver,
   Embed: {
     type: embed => stringToEnum(embed.type),
   },

--- a/src/resolvers/northstar.js
+++ b/src/resolvers/northstar.js
@@ -60,7 +60,7 @@ const resolvers = {
       updateSchoolId(args.id, args.schoolId, context),
   },
 
-  AbsoluteUrl: URLResolver,
+  URL: URLResolver,
 
   Date: DateResolver,
 

--- a/src/resolvers/rogue.js
+++ b/src/resolvers/rogue.js
@@ -101,7 +101,7 @@ const resolvers = {
     deleteSignup: (_, args, context) => deleteSignup(args.id, context),
   },
 
-  AbsoluteUrl: URLResolver,
+  URL: URLResolver,
 
   Action: {
     campaign: (action, args, context, info) =>

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -25,7 +25,7 @@ const entryFields = `
 const typeDefs = gql`
   scalar JSON
   scalar DateTime
-  scalar AbsoluteUrl
+  scalar URL
 
   enum ResizeOption {
     "Resize the image to the specified dimensions, padding the image if needed."
@@ -59,7 +59,7 @@ const typeDefs = gql`
     "The root-relative path to this resource. Use when linking internally."
     path: String
     "The full absolute URL to this resource. Use when linking cross-domain."
-    url: AbsoluteUrl
+    url: URL
   }
 
   type Asset {
@@ -72,7 +72,7 @@ const typeDefs = gql`
     "Mime-type for this asset."
     contentType: String,
     "The URL where this file is available at."
-    url(w: Int, h: Int, fit: ResizeOption): AbsoluteUrl,
+    url(w: Int, h: Int, fit: ResizeOption): URL,
   }
 
   type CampaignWebsite implements Showcasable & Routable {
@@ -85,7 +85,7 @@ const typeDefs = gql`
     "The root-relative path to this campaign. Use when linking internally."
     path: String
     "The full absolute URL to this campaign. Use when linking cross-domain."
-    url: AbsoluteUrl
+    url: URL
     "The block to display after a user signs up for a campaign."
     affirmation: Block
     "The call to action tagline for this campaign."
@@ -137,7 +137,7 @@ const typeDefs = gql`
     "The root-relative path to this story page. Use when linking internally."
     path: String
     "The full absolute URL to this story page. Use when linking cross-domain."
-    url: AbsoluteUrl
+    url: URL
     "The user-facing title for this story campaign."
     title: String!
     "The user-facing subtitle for this story campaign."
@@ -250,7 +250,7 @@ const typeDefs = gql`
     "The content of the campaign update."
     content: String
     "Optionally, a link to embed within the campaign update."
-    link: AbsoluteUrl
+    link: URL
     "The author to attribute the campaign update to."
     author: PersonBlock
     "The logo of the partner or sponsor that should be highlighted for this update."
@@ -315,7 +315,7 @@ const typeDefs = gql`
     "The root-relative path to this collection page. Use when linking internally."
     path: String
     "The full absolute URL to this collection page. Use when linking cross-domain."
-    url: AbsoluteUrl
+    url: URL
     "The cover image for this collection page."
     coverImage: Asset!
     "The supertitle (or title prefix)."
@@ -454,7 +454,7 @@ const typeDefs = gql`
     "Optional description of the link."
     content: String
     "The URL (or tel: number) being linked to."
-    # @TODO: Update this value to be some combination of AbsoluteUrl and valid 'tel:' String.
+    # @TODO: Update this value to be some combination of URL and valid 'tel:' String.
     link: String!
     "Optional custom text to display on the submission button."
     buttonText: String
@@ -632,7 +632,7 @@ const typeDefs = gql`
 
   type SocialDriveBlock implements Block {
     "The link for this social drive, with dynamic string tokens."
-    link: AbsoluteUrl
+    link: URL
     "The user-facing title for this social drive block."
     title: String
     "The user-facing description for this social drive block."
@@ -662,7 +662,7 @@ const typeDefs = gql`
     "Optional description of the link."
     content: String
     "The URL being linked to."
-    link: AbsoluteUrl
+    link: URL
     "This will hide the link preview 'embed' on the share action."
     hideEmbed: Boolean
     "This block should be displayed in a modal after a successful share."
@@ -738,7 +738,7 @@ const typeDefs = gql`
     "The voter registration block's text content."
     content: String
     "The link to the appropriate Instapage or partner flow."
-    link: AbsoluteUrl
+    link: URL
     "Any custom overrides for this block."
     additionalContent: JSON
     ${blockFields}

--- a/src/schema/embed.js
+++ b/src/schema/embed.js
@@ -9,7 +9,7 @@ import resolvers from '../resolvers/embed';
  * @var {String}
  */
 const typeDefs = gql`
-  scalar AbsoluteUrl
+  scalar URL
 
   enum EmbedType {
     "This type is used for representing static photos."
@@ -34,19 +34,19 @@ const typeDefs = gql`
     "The metatag description for a link."
     description: String
     "A URL for the author/owner of the resource."
-    authorUrl: AbsoluteUrl
+    authorUrl: URL
     "The name of the resource provider."
     providerName: String
     "The URL of the resource provider."
-    providerUrl: AbsoluteUrl
+    providerUrl: URL
     "A URL to a thumbnail image representing the resource."
-    thumbnailUrl: AbsoluteUrl
+    thumbnailUrl: URL
     "The width of the optional thumbnail."
     thumbnailWidth: Int
     "The height of the optional thumbnail."
     thumbnailHeight: Int
     "For photo embeds, the source URL of the image."
-    url: AbsoluteUrl
+    url: URL
     "The width in pixels of the video, image, or rich embed."
     height: Int
     "The height in pixels of the video, image, or rich embed."
@@ -56,7 +56,7 @@ const typeDefs = gql`
   }
 
   type Query {
-    embed(url: AbsoluteUrl!): Embed
+    embed(url: URL!): Embed
   }
 `;
 

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -15,7 +15,7 @@ const typeDefs = gql`
 
   scalar DateTime
 
-  scalar AbsoluteUrl
+  scalar URL
 
   directive @requires(fields: String!) on FIELD_DEFINITION
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -14,7 +14,7 @@ const typeDefs = gql`
 
   scalar DateTime
 
-  scalar AbsoluteUrl
+  scalar URL
 
   directive @requires(fields: String!) on FIELD_DEFINITION
 
@@ -588,7 +588,7 @@ const typeDefs = gql`
       w: Int
       "The desired image height, in pixels."
       h: Int
-    ): AbsoluteUrl
+    ): URL
     "The text content of the post, provided by the user."
     text: String
   }
@@ -628,7 +628,7 @@ const typeDefs = gql`
       w: Int
       "The desired image height, in pixels."
       h: Int
-    ): AbsoluteUrl
+    ): URL
     "The text content of the post, provided by the user."
     text: String
     "The ID of the associated signup for this post."


### PR DESCRIPTION
### What's this PR do?

This pull request (alongside DoSomething/phoenix-next#2429) fixes an issue I'd introduced in the embed component when swapping the dependency that provides this scalar in DoSomething/graphql#297. I'd hoped that this would be a non-breaking change (by keeping the old `AbsoluteUrl` name in the schema), but it turns out [the `name` in the resolver](https://github.com/Urigo/graphql-scalars/blob/master/src/scalars/URL.ts#L4) makes that impossible to change gracefully on our end! 😩

### How should this be reviewed?

This addresses this error on our Embed Block query, as seen on [Test Teens for Jeans](https://dev.dosomething.org/us/campaigns/test-teens-for-jeans/action):

```
Unknown type "AbsoluteUrl".
```

~I'll make a follow-up PR to update [this scalar's usage](https://github.com/DoSomething/phoenix-next/search?q=AbsoluteUrl) in Phoenix.~ Updated this in Phoenix in DoSomething/phoenix-next#2429.

### Any background context you want to provide?

I'm a little bummed with how difficult it is to rename scalar types in a non-breaking way! Looking forward to [this RFC](https://git.io/JkU7v) landing.

### Relevant tickets

References [Pivotal #175625159](https://www.pivotaltracker.com/story/show/175625159).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
