### PR TITLE
Fix issue with empty query strings being serialized.

### DIFF
--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -5,6 +5,8 @@ import {
   has,
   camelCase,
   omit,
+  omitBy,
+  isNil,
   isUndefined,
   values,
 } from 'lodash';
@@ -131,3 +133,11 @@ export const getOptional = (schema, type) => {
     .filter(astNode => hasDirective(astNode, 'optional'))
     .map(astNode => astNode.name.value);
 };
+
+/**
+ * Remove items from object with null or undefined values.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export const withoutNil = data => omitBy(data, isNil);

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -7,6 +7,7 @@ import config from '../../config';
 import Collection from './Collection';
 import { enumToString } from '../resolvers/helpers';
 import {
+  withoutNil,
   transformItem,
   transformCollection,
   authorizedRequest,
@@ -225,7 +226,7 @@ export const getPaginatedCampaigns = async (args, context) => {
 export const fetchPosts = async (args, context, additionalQuery) => {
   const queryString = stringify({
     pagination: 'cursor',
-    filter: {
+    filter: withoutNil({
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
@@ -239,7 +240,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       tag: args.tags ? args.tags.join(',') : undefined,
       type: args.type,
       volunteer_credit: args.volunteerCredit,
-    },
+    }),
     ...additionalQuery,
   });
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where empty query strings were being included when we had optional values on a query (e.g. `campaignId` on our `paginatedPosts` query). This would cause us to explicitly query for items where that was _empty_, rather than just discarding the field!

### How should this be reviewed?

Here's the "No Sew Mask" campaign inbox on my local, before:

![Screen Shot 2020-11-10 at 12 43 33 PM](https://user-images.githubusercontent.com/583202/98711050-7d375200-2352-11eb-9871-0661baaec747.png)

And after:

![Screen Shot 2020-11-10 at 12 44 24 PM](https://user-images.githubusercontent.com/583202/98711063-80324280-2352-11eb-8676-a62ede7d1a58.png)

### Any background context you want to provide?

My guess is that this is due to a change in how the `qs` dependency deals with nil values, since as far as I can remember these were always discarded "safely" in the the past.

I'll do another pass for other queries that may be affected & add a test case in a follow-up PR.

### Relevant tickets

References [Pivotal #175669154](https://www.pivotaltracker.com/story/show/175669154).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
