### PR TITLE
Algolia Campaign Search - Filter by Website Campaigns

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -1,7 +1,7 @@
-import { get, isNull } from 'lodash';
 import { getUnixTime } from 'date-fns';
 import algoliasearch from 'algoliasearch';
 import { DataSource } from 'apollo-datasource';
+import { get, isNull, isUndefined } from 'lodash';
 
 import config from '../../config';
 
@@ -100,6 +100,7 @@ class Algolia extends DataSource {
       causes = [],
       isOpen = true,
       hasScholarship = null,
+      hasWebsite,
       perPage = 20,
       term = '',
     } = options;
@@ -116,6 +117,10 @@ class Algolia extends DataSource {
       filters += hasScholarship
         ? this.filterScholarshipCampaigns
         : this.filterNonScholarshipCampaigns;
+    }
+
+    if (!isUndefined(hasWebsite)) {
+      filters += ` AND has_website = ${hasWebsite ? '1' : '0'}`;
     }
 
     // If specified, append filter for campaign causes.

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -19,6 +19,8 @@ const typeDefs = gql`
       hasScholarship: Boolean
       "Filter by campaigns containing these causes."
       causes: [String]
+      "Filter for campaigns that have a Contentful campaign associated."
+      hasWebsite: Boolean
       "Number of results per page."
       perPage: Int
       "Pagination search cursor for the specified search location."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the ability to filter Algolia campaign searches by website campaigns via a new `hasWebsite` parameter.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We've added a new computed boolean attribute to Algolia campaigns in https://github.com/DoSomething/rogue/pull/1146. More context there on this approach there but essentially, this backfills the [existing](https://github.com/DoSomething/graphql/blob/285b03903c3889be51ecb09b36bf1bc75530bccd/src/schema/rogue.js#L83-L84) `hasWebsite` filter on Rogue campaigns and allows us to perform the same filtering on Algolia searches. This is the final piece (alongside #294 & #301) to allow us to swap the Phoenix [Paginated Campaigns gallery](https://github.com/DoSomething/phoenix-next/blob/d348a17b149cc0a2afa7bb3b1c7624a8c78f2200/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js#L26-L48) to be powered by Algolia 🎉  

I successfully ran the command on Rogue dev to re-import the existing campaigns into our [Algolia index](https://www.algolia.com/apps/P5JW2OEUP0/explorer/browse/development_campaigns) which are now equipped with the new `has_website` attribute. I'll run this on the other indices pending this PR:
![image](https://user-images.githubusercontent.com/12417657/99316189-e7a83080-2831-11eb-9b3c-0e4e425d086a.png)


### Relevant tickets

References [Pivotal #173817560](https://www.pivotaltracker.com/story/show/173817560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.


Example Request:
```

  searchCampaigns(hasWebsite: true) {
    edges {
      node {
        contentfulCampaignId
      }
    }
  }

```

Response:
```
"data": {
    "searchCampaigns": {
      "edges": [
        {
          "node": {
            "contentfulCampaignId": "5kfd9rnZuwKsA6qIwKOaKm"
          }
        },
        {
          "node": {
            "contentfulCampaignId": "4P1isZqnSEM8aggmIgmaAs"
          }
        }
      ]
    }
}
```
