### PR TITLE
Fix issues formatting query strings.

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -67,7 +67,15 @@ export const mock = {
  * @param {string} graphqlQuery - The query to run!
  * @param {object} variables - Query variables.
  */
-export const query = (graphqlQuery, variables = {}) => {
+export const query = async (graphqlQuery, variables = {}) => {
   const client = createTestClient(new ApolloServer({ schema }));
-  return client.query({ query: graphqlQuery, variables });
+  const result = await client.query({ query: graphqlQuery, variables });
+
+  // If GraphQL errors are returned from this query, then throw
+  // them as an exception so that they fail our test suite:
+  if (result.errors) {
+    throw result.errors[0];
+  }
+
+  return result;
 };

--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -23,6 +23,31 @@ describe('Rogue', () => {
     expect(data.posts).toHaveLength(3);
   });
 
+  // @see: https://www.pivotaltracker.com/n/projects/2328687/stories/175669154
+  it('can fetch posts with omitted optional filter', async () => {
+    const posts = await factory('post', 3);
+
+    const rogueMock = mock.get(`${ROGUE_URL}/api/v3/posts/`, { data: posts });
+
+    await query(
+      gql`
+        query QueryWithOptionalVariable($campaignId: String) {
+          posts(campaignId: $campaignId, count: 3) {
+            id
+            type
+          }
+        }
+      `,
+      { campaignId: null },
+    );
+
+    const [url] = rogueMock.lastCall();
+
+    expect(url).toEqual(
+      `${ROGUE_URL}/api/v3/posts/?pagination=cursor&limit=3&page=1`,
+    );
+  });
+
   it('can fetch post with user', async () => {
     const post = await factory('post', { id: 15 });
     const user = await factory('user', { id: post.northstar_id });

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -150,5 +150,4 @@ export const withoutNil = data => omitBy(data, isNil);
  * @return {String}
  */
 export const querify = queryValues =>
-  // @TODO: Keeping the old (incorrect) behavior to demonstrate test.
-  stringify(queryValues, { skipNulls: false, addQueryPrefix: true });
+  stringify(queryValues, { skipNulls: true, addQueryPrefix: true });

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -1,3 +1,4 @@
+import { stringify } from 'qs';
 import { URL, URLSearchParams } from 'url';
 import {
   map,
@@ -141,3 +142,13 @@ export const getOptional = (schema, type) => {
  * @return {Object}
  */
 export const withoutNil = data => omitBy(data, isNil);
+
+/**
+ * Create a query string from the given object.
+ *
+ * @param {Object} values
+ * @return {String}
+ */
+export const querify = queryValues =>
+  // @TODO: Keeping the old (incorrect) behavior to demonstrate test.
+  stringify(queryValues, { skipNulls: false, addQueryPrefix: true });

--- a/src/repositories/northstar.js
+++ b/src/repositories/northstar.js
@@ -1,10 +1,10 @@
-import { stringify } from 'qs';
 import logger from 'heroku-logger';
 import { intersection, snakeCase } from 'lodash';
 
 import schema from '../schema';
 import config from '../../config';
 import {
+  querify,
   getOptional,
   transformItem,
   authorizedRequest,
@@ -32,7 +32,7 @@ export const getUserById = async (id, fields, context) => {
   logger.debug('Loading user from Northstar', { id, include });
 
   try {
-    const url = `${NORTHSTAR_URL}/v2/users/${id}?${stringify({ include })}`;
+    const url = `${NORTHSTAR_URL}/v2/users/${id}${querify({ include })}`;
     const response = await fetch(url, authorizedRequest(context));
 
     const json = await response.json();
@@ -65,7 +65,7 @@ export const getUsers = async (args, fields, context) => {
   logger.debug('Loading users from Northstar', { search, include });
 
   try {
-    const url = `${NORTHSTAR_URL}/v2/users?${stringify({
+    const url = `${NORTHSTAR_URL}/v2/users${querify({
       pagination: 'cursor',
       include,
       search,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -622,13 +622,13 @@ export const getSignupsById = async (ids, options) => {
     ids,
   });
 
-  const queryString = {
+  const queryString = querify({
     filter: {
       id: ids.join(','),
     },
     limit: 100,
     pagination: 'cursor',
-  };
+  });
 
   const response = await fetch(
     `${ROGUE_URL}/api/v3/signups/${queryString}`,

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -624,7 +624,7 @@ export const getSignupsById = async (ids, options) => {
 
   const queryString = {
     filter: {
-      ids: ids.join(','),
+      id: ids.join(','),
     },
     limit: 100,
     pagination: 'cursor',

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -1,4 +1,3 @@
-import { stringify } from 'qs';
 import pluralize from 'pluralize';
 import logger from 'heroku-logger';
 import { find, isUndefined, omit, zipWith } from 'lodash';
@@ -7,7 +6,7 @@ import config from '../../config';
 import Collection from './Collection';
 import { enumToString } from '../resolvers/helpers';
 import {
-  withoutNil,
+  querify,
   transformItem,
   transformCollection,
   authorizedRequest,
@@ -47,8 +46,12 @@ export const getActionsByCampaignId = async (campaignId, context) => {
     campaignId,
   });
 
+  const queryString = querify({
+    filter: { campaign_id: campaignId },
+  });
+
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/actions/?filter[campaign_id]=${campaignId}`,
+    `${ROGUE_URL}/api/v3/actions/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -84,7 +87,7 @@ export const fetchActionStats = async (args, context, additionalQuery = {}) => {
     isUndefined,
   );
 
-  const queryString = stringify({
+  const queryString = querify({
     filter,
     orderBy: args.orderBy,
     pagination: 'cursor',
@@ -92,7 +95,7 @@ export const fetchActionStats = async (args, context, additionalQuery = {}) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/action-stats/?${queryString}`,
+    `${ROGUE_URL}/api/v3/action-stats/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -169,7 +172,7 @@ export const fetchCampaigns = async (args, context, additionalQuery = {}) => {
     isUndefined,
   );
 
-  const queryString = stringify({
+  const queryString = querify({
     filter,
     orderBy: args.orderBy,
     pagination: 'cursor',
@@ -179,7 +182,7 @@ export const fetchCampaigns = async (args, context, additionalQuery = {}) => {
   logger.info('Loading campaigns from Rogue', { queryString });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/campaigns/?${queryString}`,
+    `${ROGUE_URL}/api/v3/campaigns/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -224,9 +227,9 @@ export const getPaginatedCampaigns = async (args, context) => {
  * @return {Promise}
  */
 export const fetchPosts = async (args, context, additionalQuery) => {
-  const queryString = stringify({
+  const queryString = querify({
     pagination: 'cursor',
-    filter: withoutNil({
+    filter: {
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
       campaign_id: args.campaignId,
@@ -240,7 +243,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
       tag: args.tags ? args.tags.join(',') : undefined,
       type: args.type,
       volunteer_credit: args.volunteerCredit,
-    }),
+    },
     ...additionalQuery,
   });
 
@@ -250,7 +253,7 @@ export const fetchPosts = async (args, context, additionalQuery) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?${queryString}`,
+    `${ROGUE_URL}/api/v3/posts/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -311,8 +314,18 @@ export const getPostById = async (id, context) => {
  * @return {Array}
  */
 export const getPostsByUserId = async (id, page, count, context) => {
+  const queryString = querify({
+    filter: {
+      northstar_id: id,
+      type: 'photo,text',
+    },
+    page,
+    limit: count,
+    pagination: 'cursor',
+  });
+
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?filter[northstar_id]=${id}&filter[type]=photo,text&page=${page}&limit=${count}&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/posts/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -328,8 +341,18 @@ export const getPostsByUserId = async (id, page, count, context) => {
  * @return {Array}
  */
 export const getPostsByCampaignId = async (id, page, count, context) => {
+  const queryString = querify({
+    filter: {
+      campaign_id: id,
+      type: 'photo,text',
+    },
+    page,
+    limit: count,
+    pagination: 'cursor',
+  });
+
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?filter[campaign_id]=${id}&filter[type]=photo,text&page=${page}&limit=${count}&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/posts/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -345,8 +368,13 @@ export const getPostsByCampaignId = async (id, page, count, context) => {
  * @return {Array}
  */
 export const getPostsBySignupId = async (id, context) => {
+  const queryString = querify({
+    filter: { signup_id: id },
+    pagination: 'cursor',
+  });
+
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?filter[signup_id]=${id}&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/posts/${queryString}`,
     authorizedRequest(context),
   );
   const json = await response.json();
@@ -379,7 +407,7 @@ export const toggleReaction = async (postId, context) => {
 export const updatePostQuantity = async (postId, quantity, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
     method: 'PATCH',
-    body: JSON.stringify({ quantity }),
+    body: JSON.querify({ quantity }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -396,7 +424,7 @@ export const updatePostQuantity = async (postId, quantity, context) => {
 export const reviewPost = async (postId, status, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/reviews`, {
     method: 'POST',
-    body: JSON.stringify({ status: status.toLowerCase() }),
+    body: JSON.querify({ status: status.toLowerCase() }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -413,7 +441,7 @@ export const reviewPost = async (postId, status, context) => {
 export const tagPost = async (postId, tag, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/tags`, {
     method: 'POST',
-    body: JSON.stringify({ tag_name: tag.toLowerCase() }),
+    body: JSON.querify({ tag_name: tag.toLowerCase() }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -430,7 +458,7 @@ export const tagPost = async (postId, tag, context) => {
 export const rotatePost = async (postId, degrees, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/rotate`, {
     method: 'POST',
-    body: JSON.stringify({ degrees }),
+    body: JSON.querify({ degrees }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -506,7 +534,7 @@ export const makeImpactStatement = post => {
  * @return {Array}
  */
 export const fetchSignups = async (args, context, additionalQuery) => {
-  const queryString = stringify({
+  const queryString = querify({
     filter: {
       campaign_id: args.campaignId,
       group_id: args.groupId,
@@ -525,7 +553,7 @@ export const fetchSignups = async (args, context, additionalQuery) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/signups/?${queryString}`,
+    `${ROGUE_URL}/api/v3/signups/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -594,11 +622,19 @@ export const getSignupsById = async (ids, options) => {
     ids,
   });
 
-  const idQuery = ids.join(',');
+  const queryString = {
+    filter: {
+      ids: ids.join(','),
+    },
+    limit: 100,
+    pagination: 'cursor',
+  };
+
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/signups/?filter[id]=${idQuery}&limit=100&pagination=cursor`,
+    `${ROGUE_URL}/api/v3/signups/${queryString}`,
     options,
   );
+
   const json = await response.json();
   const signups = transformCollection(json);
 
@@ -616,7 +652,7 @@ export const getSignupsById = async (ids, options) => {
  * @return {Array}
  */
 export const getSignupsByUserId = async (args, context) => {
-  const queryString = stringify({
+  const queryString = querify({
     filter: {
       northstar_id: args.id,
     },
@@ -632,7 +668,7 @@ export const getSignupsByUserId = async (args, context) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/signups/?${queryString}`,
+    `${ROGUE_URL}/api/v3/signups/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -657,7 +693,7 @@ export const createSignup = async (args, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/signups`, {
     method: 'POST',
     ...requireAuthorizedRequest(context),
-    body: JSON.stringify({
+    body: JSON.querify({
       campaign_id: args.campaignId,
       details: args.details,
     }),
@@ -699,7 +735,7 @@ export const deleteSignup = async (signupId, context) => {
  * @return Int
  */
 export const getSignupsCount = async (args, context) => {
-  const queryString = stringify({
+  const queryString = querify({
     filter: {
       campaign_id: args.campaignId,
       northstar_id: args.userId,
@@ -714,7 +750,7 @@ export const getSignupsCount = async (args, context) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/signups/?${queryString}`,
+    `${ROGUE_URL}/api/v3/signups/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -743,7 +779,7 @@ export const getSignupsCount = async (args, context) => {
  * @return Int
  */
 export const getPostsCount = async (args, context) => {
-  const queryString = stringify({
+  const queryString = querify({
     filter: {
       action: args.action,
       action_id: args.actionIds ? args.actionIds.join(',') : undefined,
@@ -766,7 +802,7 @@ export const getPostsCount = async (args, context) => {
   });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/posts/?${queryString}`,
+    `${ROGUE_URL}/api/v3/posts/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -869,7 +905,7 @@ export const getGroupById = async (id, context) => {
  * @return {Array}
  */
 export const fetchGroups = async (args, context, additionalQuery) => {
-  const queryString = stringify({
+  const queryString = querify({
     pagination: 'cursor',
     filter: {
       group_type_id: args.groupTypeId,
@@ -883,7 +919,7 @@ export const fetchGroups = async (args, context, additionalQuery) => {
   logger.info('Loading groups from Rogue', { args, queryString });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/groups/?${queryString}`,
+    `${ROGUE_URL}/api/v3/groups/${queryString}`,
     authorizedRequest(context),
   );
 
@@ -962,7 +998,7 @@ export const getGroupTypes = async (args, context) => {
  * @return {Array}
  */
 export const fetchClubs = async (args, context, additionalQuery) => {
-  const queryString = stringify({
+  const queryString = querify({
     filter: {
       name: args.name,
     },
@@ -973,7 +1009,7 @@ export const fetchClubs = async (args, context, additionalQuery) => {
   logger.info(' Loading clubs from Rogue', { args, queryString });
 
   const response = await fetch(
-    `${ROGUE_URL}/api/v3/clubs?${queryString}`,
+    `${ROGUE_URL}/api/v3/clubs${queryString}`,
     authorizedRequest(context),
   );
 

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -407,7 +407,7 @@ export const toggleReaction = async (postId, context) => {
 export const updatePostQuantity = async (postId, quantity, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}`, {
     method: 'PATCH',
-    body: JSON.querify({ quantity }),
+    body: JSON.stringify({ quantity }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -424,7 +424,7 @@ export const updatePostQuantity = async (postId, quantity, context) => {
 export const reviewPost = async (postId, status, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/reviews`, {
     method: 'POST',
-    body: JSON.querify({ status: status.toLowerCase() }),
+    body: JSON.stringify({ status: status.toLowerCase() }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -441,7 +441,7 @@ export const reviewPost = async (postId, status, context) => {
 export const tagPost = async (postId, tag, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/tags`, {
     method: 'POST',
-    body: JSON.querify({ tag_name: tag.toLowerCase() }),
+    body: JSON.stringify({ tag_name: tag.toLowerCase() }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -458,7 +458,7 @@ export const tagPost = async (postId, tag, context) => {
 export const rotatePost = async (postId, degrees, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/posts/${postId}/rotate`, {
     method: 'POST',
-    body: JSON.querify({ degrees }),
+    body: JSON.stringify({ degrees }),
     ...requireAuthorizedRequest(context),
   });
 
@@ -693,7 +693,7 @@ export const createSignup = async (args, context) => {
   const response = await fetch(`${ROGUE_URL}/api/v3/signups`, {
     method: 'POST',
     ...requireAuthorizedRequest(context),
-    body: JSON.querify({
+    body: JSON.stringify({
       campaign_id: args.campaignId,
       details: args.details,
     }),


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on the quick fix from #299 with an improved `querify` helper function that correctly omits null values from the query string. This addresses the same bug described in that PR in a more generalized & clearer way.

### How should this be reviewed?

I refactored our resolvers to use this function (instead of string interpolation or directly calling `stringify`) in 9b6acbf, then added a test demonstrating the old issue we were facing in 659aa97. I then "re-fixed" the bug in ab9a1ab.

I also fixed an unrelated issue where GraphQL errors would not be clearly reported in test failures in 6eb3aba.

### Any background context you want to provide?

At some point, I believe we started getting `null` for unused variables instead of `undefined` & so `qs`'s default behavior no longer stripped them from the query string. I can't find this change in `graphql`, `apollo-server`, or `apollo-client`'s changelogs, but I imagine it must have been one of them...

### Relevant tickets

References [Pivotal #175669154](https://www.pivotaltracker.com/story/show/175669154).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
