### PR TITLE
Patch isOpen filter on Algolia campaign search

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -61,7 +61,7 @@ class Algolia extends DataSource {
   get filterOpenCampaigns() {
     const now = getUnixTime(Date.now());
 
-    return `start_date < ${now} AND end_date > ${now}`;
+    return `start_date < ${now} AND (is_evergreen=1 OR end_date > ${now})`;
   }
 
   /**


### PR DESCRIPTION
### What's this PR do?

This pull request uses the new `is_evergreen` computed attribute added in https://github.com/DoSomething/rogue/pull/1147 to filter for evergreen campaigns (with no assigned `end_date`).

### How should this be reviewed?
👀 

### Any background context you want to provide?
Previously, evergreen campaigns were not returned when querying with the `isOpen` filter since the `end_date` would be `null` and thus fail the condition. Algolia recommends using a computed boolean attribute to filter against `null` values.

### Relevant tickets

References [Pivotal #173817560](https://www.pivotaltracker.com/story/show/173817560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
