### PR TITLE
Algolia Campaigns Search orderBy parameter bug fix

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -107,7 +107,7 @@ class Algolia extends DataSource {
     } = options;
 
     // e.g. "start_date,desc" => ["start_date", "desc"].
-    const [attribute, direction] = orderBy.split(',');
+    const [attribute, direction] = orderBy ? orderBy.split(',') : [];
     // If an orderBy is specified, we'll need to query the replica index. We append the sorting strategy to the index
     // name following the replica naming convention (https://bit.ly/32mxQWZ).
     const indexReplicaSuffix =


### PR DESCRIPTION
### What's this PR do?

This pull request adds a fail-safe to the `orderBy` parsing logic to ensure that if `orderBy: null` is explicitly passed through as a parameter to the `searchCampaigns` query, we won't attempt to `split` the parameter.

### How should this be reviewed?
👀 

### Any background context you want to provide?
On Phoenix, the `PaginatedCampaignGallery` will [always pass through](https://github.com/DoSomething/phoenix-next/blob/03716ad136a3d00b5a31e36bf6bceba99e306118/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js#L68) the `orderBy` parameter which will be `null`
 by default (something I didn't realize! I would have expected it to be `undefined` and thus trigger the [default value](https://github.com/DoSomething/graphql/blob/64dd034482dbdca7cc68572ef64e95dd7eeb85dd/src/dataSources/Algolia.js#L104) in the Algolia repository method).

### Relevant tickets

References [Pivotal #175582776](https://www.pivotaltracker.com/story/show/175582776/comments/219894583).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
