### PR TITLE
Fix issue pluralizing nouns with "(s)" in them.

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -516,7 +516,12 @@ export const makeImpactStatement = post => {
   }
 
   const { noun, verb } = post.actionDetails.data;
-  const statement = pluralize(noun, post.quantity, true);
+
+  // Sometimes editors will include "(s)" in nouns, which prevents pluralization.
+  // References: https://www.pivotaltracker.com/story/show/175358000
+  const sanitizedNoun = noun.replace('(s)', '');
+
+  const statement = pluralize(sanitizedNoun, post.quantity, true);
 
   return `${statement} ${verb}`;
 };


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue pluralizing nouns with `(s)` in them, like `mask(s)`. Since [pluralize](https://www.npmjs.com/package/pluralize) doesn't recognize this, it would improperly pluralize to `12 mask(s)s`. To prevent this, we remove `(s)` from any nouns before formatting.

### How should this be reviewed?

👀

### Any background context you want to provide?

🔌

### Relevant tickets

References [Pivotal #175358000](https://www.pivotaltracker.com/story/show/175358000).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
