### PR TITLE
Throw exception if we receive an error.

### DIFF
--- a/src/__tests__/rogue.spec.js
+++ b/src/__tests__/rogue.spec.js
@@ -193,4 +193,25 @@ describe('Rogue', () => {
 
     expect(data.groupTypes).toHaveLength(3);
   });
+
+  it('reports errors it receives', async () => {
+    const POST_QUERY = gql`
+      {
+        posts(count: 3) {
+          id
+          type
+        }
+      }
+    `;
+
+    // For example, if we provided a bad access token...
+    mock.get(`${ROGUE_URL}/api/v3/posts/`, {
+      error: 'access_denied',
+      message: 'Access token could not be verified.',
+    });
+
+    return expect(query(POST_QUERY)).rejects.toThrow(
+      'Access token could not be verified.',
+    );
+  });
 });

--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -54,6 +54,10 @@ export const requireAuthorizedRequest = context => {
 export const transformResponse = (data, idField = 'id') => {
   const result = mapKeys(data, (_, key) => camelCase(key));
 
+  if (data.error) {
+    throw new Error(data.message || 'Unexpected error');
+  }
+
   if (!has(result, idField)) {
     return null;
   }
@@ -91,8 +95,13 @@ export const transformItem = json => transformResponse(json.data, 'id');
  * @param {Object} json
  * @return {Object}
  */
-export const transformCollection = json =>
-  map(json.data, data => transformResponse(data, 'id'));
+export const transformCollection = json => {
+  if (json.error) {
+    throw new Error(json.message || 'Unexpected error');
+  }
+
+  return map(json.data, data => transformResponse(data, 'id'));
+};
 
 /**
  * Append a URL with optional query string arguments.


### PR DESCRIPTION
### What's this PR do?

This pull request updates our `transformResponse` and `transformCollection` helpers to throw an exception if we receive an error in the JSON response. This fixes an issue where we'd previously "silently" handle these errors and return `null` or `[]` to the user, which made debugging issues more confusing than it needs to be.

### How should this be reviewed?

See included test case!

### Any background context you want to provide?

💣

### Relevant tickets

References [Pivotal #170775477](https://www.pivotaltracker.com/story/show/170775477).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
