### PR TITLE
Adds check for existence of json.error

### DIFF
--- a/src/repositories/helpers.js
+++ b/src/repositories/helpers.js
@@ -54,7 +54,7 @@ export const requireAuthorizedRequest = context => {
 export const transformResponse = (data, idField = 'id') => {
   const result = mapKeys(data, (_, key) => camelCase(key));
 
-  if (data.error) {
+  if (has(data, 'error')) {
     throw new Error(data.message || 'Unexpected error');
   }
 
@@ -96,7 +96,7 @@ export const transformItem = json => transformResponse(json.data, 'id');
  * @return {Object}
  */
 export const transformCollection = json => {
-  if (json.error) {
+  if (has(json, 'error')) {
     throw new Error(json.message || 'Unexpected error');
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request is a followup to #307,  adding a check for the existence of an `error` property. This should hopefully clear up the `Cannot read property 'error' of undefined` errors we've seen this week.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I've manually tested by querying for a user that doesn't exist, which seems to be the source of many of these errors.

Example request:
```
{
  user(id:"abc") {
    id
    firstName
  }
}
```

Example response:
```
{
  "data": {
    "user": null
  },
 ...
```

On master, this query will log: `[warn] Unable to load user. id=abc error="Cannot read property 'error' of undefined"`

On this branch, we don't see the log... but wouldn't we still want to that we were unable to load the user?

### Relevant tickets

References [Pivotal #175955292](https://www.pivotaltracker.com/story/show/175955292).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
