### PR TITLE
Algolia Campaigns Search - Exclude Campaign IDs Filter

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -92,6 +92,16 @@ class Algolia extends DataSource {
   }
 
   /**
+   * Exclude list of campaign IDs.
+   *
+   * @param {Array} ids
+   * @return {String}
+   */
+  filterExcludedIds(ids) {
+    return ids.map(id => ` AND id!=${id}`).join(' ');
+  }
+
+  /**
    * Search campaigns index
    */
   async searchCampaigns(options = {}) {
@@ -104,6 +114,7 @@ class Algolia extends DataSource {
       orderBy = '',
       perPage = 20,
       term = '',
+      excludeIds = [],
     } = options;
 
     // e.g. "start_date,desc" => ["start_date", "desc"].
@@ -134,6 +145,11 @@ class Algolia extends DataSource {
     // If specified, append filter for campaign causes.
     if (causes.length) {
       filters += this.filterCauses(causes);
+    }
+
+    // If specified, append filter to exclude campaigns with provided IDs.
+    if (excludeIds.length) {
+      filters += this.filterExcludedIds(excludeIds);
     }
 
     const results = await index.search(term, {

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -27,6 +27,8 @@ const typeDefs = gql`
       orderBy: String
       "Pagination search cursor for the specified search location."
       cursor: String
+      "Exclude campaigns with specified IDs"
+      excludeIds: [Int]
     ): AlgoliaCampaignCollection!
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `excludeIds` filter to the Algolia `searchCampaigns` query to exclude a list of Campaign IDs from the results.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will allow us to exclude particular campaigns from queries E.g. On the website, when we want a list of scholarship campaigns to recommend to the user, excluding the campaign they've recently reported back on. (This so happens to be our use case).

I wondered if there was a formal way to exclude an array of values for an attribute from a query (a la SQL `NOT IN`), but [it seems](https://www.algolia.com/doc/api-reference/api-parameters/filters/) that we do have to map through each value individually. I tested this with an array of 100 IDs and it still worked pretty darn quickly!

I borrowed the `exclude` nomenclature from [Rogue's `exclude` filter](https://github.com/DoSomething/rogue/blob/9c83e89167f6e1853711e3a91440abc36500f754/app/Http/Controllers/Traits/FiltersRequests.php#L33-L39).

### Relevant tickets

References [Pivotal #175358477](https://www.pivotaltracker.com/story/show/175358477).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

**Example Query:**
```
{
  searchCampaigns(excludeIds: [958, 946, 9112, 9111]) {
    edges {
      node {
        id
      }
    }
  }
}
```

**Response:**
```
{
  "data": {
    "searchCampaigns": {
      "edges": [
        {
          "node": {
            "id": 9110
          }
        },
        {
          "node": {
            "id": 9109
          }
        },
        {
          "node": {
            "id": 9108
          }
        },
...
```
