### PR TITLE
isGroupCampaign Filter - Algolia Campaigns Search

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -109,6 +109,7 @@ class Algolia extends DataSource {
       cursor = '0',
       causes = [],
       isOpen = true,
+      isGroupCampaign,
       hasScholarship = null,
       hasWebsite,
       orderBy = '',
@@ -130,6 +131,11 @@ class Algolia extends DataSource {
     let filters = isOpen
       ? this.filterOpenCampaigns
       : this.filterClosedCampaigns;
+
+    // If specified, filter for only group/non-group campaigns.
+    if (!isUndefined(isGroupCampaign)) {
+      filters += ` AND is_group_campaign = ${isGroupCampaign ? '1' : '0'}`;
+    }
 
     // If specified, append filter for scholarship/non-scholarship campaigns
     if (!isNull(hasScholarship)) {

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -15,6 +15,8 @@ const typeDefs = gql`
       term: String
       "Search for only open campaigns or only closed campaigns."
       isOpen: Boolean
+      "Search for only group or non-group campaigns."
+      isGroupCampaign: Boolean
       "Search for campaigns that have or do not have a scholarship."
       hasScholarship: Boolean
       "Filter by campaigns containing these causes."


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `isGroupCampaign` filter to the Algolia `searchCampaigns` query to toggle filtering for group/non-group campaigns per the new computed attribute in https://github.com/DoSomething/rogue/pull/1150

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will help replace some [hacky code](https://github.com/DoSomething/phoenix-next/blob/d3eb6a8f3e52f147be7053f61f13ef051be5702c/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js#L126) we've got on the Phoenix front-end to manually remove group campaigns from search results. Also will be used for the new recommended campaigns gallery on show submission pages in Phoenix.

### Relevant tickets

References [Pivotal #175358477](https://www.pivotaltracker.com/story/show/175358477).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

**Example Query**
```
{
  searchCampaigns(isGroupCampaign: false) {
    edges {
      node {
        id
        groupTypeId
      }
    }
  }
}
```

**Response**
```
{
  "data": {
    "searchCampaigns": {
      "edges": [
        {
          "node": {
            "id": 958,
            "groupTypeId": null
          }
        },
        {
          "node": {
            "id": 946,
            "groupTypeId": null
          }
        },
        {
          "node": {
            "id": 9112,
            "groupTypeId": null
          }
        },
...
```