### PR TITLE
Add hoursSpent field to the Rogue Post type

### DIFF
--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -653,6 +653,8 @@ const typeDefs = gql`
     group: Group
     "The number of items added or removed in this post."
     quantity: Int
+    "The number of hours spent for this post."
+    hoursSpent: Float
     "The human-readable impact (quantity, noun, and verb)."
     impact: String
     "The tags that have been applied to this post by DoSomething.org staffers."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the new `hours_spent` field (https://github.com/DoSomething/rogue/pull/1154) to the Rogue `Post` type.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We'll be using this field to calculate the total hours spent per action and display it on the Volunteer Certificates in Phoenix ([Pivotal #176371378](https://www.pivotaltracker.com/story/show/176371378)).

### Relevant tickets

References [Pivotal #176369915](https://www.pivotaltracker.com/story/show/176369915).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/104056323-4fd61b80-51be-11eb-9e18-3492c1950cf8.png)

