### PR TITLE
Adds PhotoPostTopic action field

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -73,6 +73,8 @@ const linkSchema = gql`
   }
 
   extend type PhotoPostTopic {
+    "The action that this topic should create photo posts for."
+    action: Action
     "The campaign that this topic should create signups and photo posts for."
     campaign: Campaign
   }
@@ -616,6 +618,22 @@ const linkResolvers = {
   },
 
   PhotoPostTopic: {
+    action: {
+      fragment:
+        'fragment ActionFragment on PhotoPostTopic { actionId }',
+      resolve(topic, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: rogueSchema,
+          operation: 'query',
+          fieldName: 'action',
+          args: {
+            id: topic.actionId,
+          },
+          context,
+          info,
+        });
+      },
+    },
     campaign: {
       fragment:
         'fragment CampaignFragment on PhotoPostTopic { legacyCampaign }',

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -619,8 +619,7 @@ const linkResolvers = {
 
   PhotoPostTopic: {
     action: {
-      fragment:
-        'fragment ActionFragment on PhotoPostTopic { actionId }',
+      fragment: 'fragment ActionFragment on PhotoPostTopic { actionId }',
       resolve(topic, args, context, info) {
         return info.mergeInfo.delegateToSchema({
           schema: rogueSchema,


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `action` field to the `PhotoPostTopic` type in Gambit Contentful, referencing the `Action` type in Rogue.

### How should this be reviewed?

Example request:

```
{
  topic(id: "6C8i1uD1rlxgGQnvNmpBaz") {
    id
    __typename
    ...TopicFields
  }
}

fragment TopicFields on PhotoPostTopic {
  actionId
  action {
    id
    volunteerCredit
  }
  completedPhotoPost
}

```

Example response:
```
{
  "data": {
    "topic": {
      "id": "6C8i1uD1rlxgGQnvNmpBaz",
      "__typename": "PhotoPostTopic",
      "actionId": 1102,
      "action": {
        "id": 1102,
        "volunteerCredit": true
      },
      "completedPhotoPost": "Thanks for sharing that with us and keep your yourself and your friends safe during the pandemic!\n\nText START if you want to submit another photo."
    }
  },
```

### Any background context you want to provide?

Gambit needs to access the nested action's `volunteerCredit` boolean to determine whether to ask members for their `hours_spent` when in a photo post conversation topic.

### Relevant tickets

References [Pivotal #176368428](https://www.pivotaltracker.com/story/show/176368428).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
