### PR TITLE
Removes WebSignupConfirmation type

### DIFF
--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -130,12 +130,9 @@ const getFields = json => {
       topic: fields.topic,
     };
   }
-  // Also known as WebSignupConfirmation
   if (contentType === 'campaign') {
     return {
       campaignId: fields.campaignId,
-      // Links ---
-      topic: fields.webSignup,
     };
   }
   // TODO: If the response is an askMultipleChoice we should inject the broadcast itself as a topic
@@ -300,33 +297,6 @@ export const getConversationTriggers = async () => {
     return map(json.items, transformItem);
   } catch (exception) {
     logger.warn('Unable to load Gambit Conversation Triggers.', {
-      query,
-      error: exception.message,
-    });
-  }
-  return [];
-};
-
-/**
- * Fetch all web signup confirmations from the Gambit Contentful space.
- *
- * @return {Array}
- */
-export const getWebSignupConfirmations = async () => {
-  const query = {
-    order: '-sys.createdAt',
-    limit: 250,
-    content_type: 'campaign',
-  };
-  query['fields.webSignup[exists]'] = true;
-
-  logger.debug('Loading Gambit Web Signup Confirmations', { query });
-
-  try {
-    const json = await contentfulClient.getEntries(query);
-    return map(json.items, transformItem);
-  } catch (exception) {
-    logger.warn('Unable to load Gambit Web Signup Confirmations.', {
       query,
       error: exception.message,
     });

--- a/src/resolvers/contentful/gambit.js
+++ b/src/resolvers/contentful/gambit.js
@@ -1,7 +1,6 @@
 import Loader from '../../loader';
 import {
   getConversationTriggers,
-  getWebSignupConfirmations,
   linkResolver,
 } from '../../repositories/contentful/gambit';
 
@@ -74,9 +73,6 @@ const resolvers = {
       return null;
     },
   },
-  LegacyCampaign: {
-    webSignup: linkResolver,
-  },
   ConversationTrigger: {
     response: linkResolver,
   },
@@ -85,8 +81,6 @@ const resolvers = {
     conversationTriggers: (_, args, context) =>
       getConversationTriggers(args, context),
     topic: (_, args, context) => Loader(context).topics.load(args.id),
-    webSignupConfirmations: (_, args, context) =>
-      getWebSignupConfirmations(args, context),
   },
   PhotoPostBroadcast: {
     attachments: linkResolver,
@@ -145,9 +139,6 @@ const resolvers = {
       }
       return null;
     },
-  },
-  WebSignupConfirmation: {
-    topic: linkResolver,
   },
 };
 

--- a/src/schema/contentful/gambit.js
+++ b/src/schema/contentful/gambit.js
@@ -62,7 +62,6 @@ const typeDefs = gql`
 
   type LegacyCampaign {
     campaignId: Int
-    webSignup: Topic
   }
 
   "Transition topic for autoReply broadcasts"
@@ -245,16 +244,6 @@ const typeDefs = gql`
     response: Topic!
   }
 
-  "Confirmation to send a user when they sign up for a campaign from web."
-  type WebSignupConfirmation {
-    "The entry id"
-    id: String!
-    "The campaign ID that the user signed up for."
-    campaignId: Int!
-    "The topic to change user conversation to."
-    topic: Topic
-  }
-
   type Query {
     "Get a broadcast by ID."
     broadcast(id: String!): Broadcast
@@ -262,8 +251,6 @@ const typeDefs = gql`
     conversationTriggers: [ConversationTrigger]
     "Get a topic by ID."
     topic(id: String!): Topic
-    "Get all web signup confirmations."
-    webSignupConfirmations: [WebSignupConfirmation]
   }
 `;
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -99,11 +99,6 @@ const linkSchema = gql`
     action: Action
   }
 
-  extend type WebSignupConfirmation {
-    "The campaign that this web signup confirmation is for."
-    campaign: Campaign
-  }
-
   extend type AskVotingPlanStatusBroadcastTopic {
     "The action that this broadcast is associated to."
     action: Action
@@ -661,25 +656,6 @@ const linkResolvers = {
           fieldName: 'campaign',
           args: {
             id: topic.legacyCampaign.campaignId,
-          },
-          context,
-          info,
-        });
-      },
-    },
-  },
-
-  WebSignupConfirmation: {
-    campaign: {
-      fragment:
-        'fragment CampaignFragment on WebSignupConfirmation { campaignId }',
-      resolve(webSignupConfirmation, args, context, info) {
-        return info.mergeInfo.delegateToSchema({
-          schema: rogueSchema,
-          operation: 'query',
-          fieldName: 'campaign',
-          args: {
-            id: webSignupConfirmation.campaignId,
           },
           context,
           info,


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `WebSignupConfirmation` type from the Gambit Contentful schema, as we're no longer querying for this field now that we've sunset signup confirmation messages for SMS per these PR's:

* https://github.com/DoSomething/gambit-admin/pull/123, https://github.com/DoSomething/gambit-admin/pull/124 - displayed `WebSignupConfirmation` lists for active and closed campaigns

* https://github.com/DoSomething/gambit/pull/546 - removed support for signup confirmation messages, which queries for all `WebSignupConfirmation` items to determine whether to send a SMS confirmation for a campaign signup

* https://github.com/DoSomething/rogue/pull/1162 - removed Gambit API request to send signup confirmation messages
 
### How should this be reviewed?

👀 

### Any background context you want to provide?

We'll eventually delete the `webSignup` field from the `campaign` content type in the Gambit Contentful space. 

Bigger picture and completely out of scope for this PR, but to provide more context-- we want to deprecate the `campaign` content type for sake of adding a numeric `campaignId` field to the only type it's currently used for, an `AutoReplyTopic`). See https://www.pivotaltracker.com/story/show/176602032 for details.

### Relevant tickets

References [Pivotal #176421196](https://www.pivotaltracker.com/story/show/176421196).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
