### PR TITLE
Update OEmbetter library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6707,7 +6707,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -9394,6 +9395,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -9408,6 +9410,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -9658,9 +9661,9 @@
       }
     },
     "oembetter": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/oembetter/-/oembetter-0.1.22.tgz",
-      "integrity": "sha512-WCNsLF4PkWnJ0tbYnAAIi0pqSb24ABX33iu8+7Ve6Sa0LQuu7L7prsUeIVbSn+E+WM5x6+N3GI2XajDHXbVXig==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/oembetter/-/oembetter-0.1.23.tgz",
+      "integrity": "sha512-Kk6jIU3HYQzZLsJrLtEqC9y7PoFz3ACiNETRhuMJXahTxabqJZ87SZCXvtJh+g2vzm9evpq7hrESkmcmoZPueA==",
       "requires": {
         "async": "^0.9.0",
         "cheerio": "^0.22.0",
@@ -11155,7 +11158,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lodash": "^4.17.19",
     "mongodb": "^3.6.3",
     "node-fetch": "^2.6.1",
-    "oembetter": "^0.1.22",
+    "oembetter": "^0.1.23",
     "page-metadata-parser": "^1.1.4",
     "pluralize": "^8.0.0",
     "qs": "^6.9.4"


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `oembetter` library we use to fetch embed metadata for URLs.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Per the investigation as to our Youtube embed [failing onsite](https://dosomething.slack.com/archives/C09ANFQLA/p1611251025003700), I figured a good first step is to update the library we use for embedding! Turns out there's a new [patch release](https://github.com/apostrophecms/oembetter/releases/tag/0.1.23), which does address Youtube embeds.

Excitingly, locally, while nothing was working before, once I updated the metadata started being properly returned! 

### Relevant tickets

References [Pivotal #171091273](https://www.pivotaltracker.com/story/show/171091273).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
