### PR TITLE
Add Action Facets Filtering for Algolia Campaigns Search

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -99,23 +99,25 @@ class Algolia extends DataSource {
    */
   filterActionTypes(actionTypes) {
     // e.g. ["make-something", "share-something"] => "actions.action_type:make-something OR actions.action_type:share-something".
-    const actionTypeFacets = actionTypes.map(actionType => `actions.action_type:${actionType}`).join(' OR ');
+    const actionTypeFacets = actionTypes
+      .map(actionType => `actions.action_type:${actionType}`)
+      .join(' OR ');
 
     return ` AND (${actionTypeFacets})`;
   }
 
   /**
    * Filter search by campaigns containing online location (boolean) (using facet filtering).
-   * 
+   *
    * @param {Boolean} online
    * @return {String}
    */
   filterOnlineLocation(online) {
-    if(!online) {
+    if (!online) {
       return ` AND NOT actions.online=1`;
     }
 
-    return ` AND actions.online=1`
+    return ` AND actions.online=1`;
   }
 
   /**

--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -121,6 +121,21 @@ class Algolia extends DataSource {
   }
 
   /**
+   * Filter search by campaigns containing these time commitments (using facet filtering).
+   *
+   * @param {Array} timeCommitments
+   * @return {String}
+   */
+  filterTimeCommitments(timeCommitments) {
+    // e.g. ["0.5-1.0", "1.0-3.0"] => "actions.time_commitment:0.5-1.0 OR actions.action_type:1.0-3.0".
+    const timeCommitmentFacets = timeCommitments
+      .map(timeCommitment => `actions.time_commitment:${timeCommitment}`)
+      .join(' OR ');
+
+    return ` AND (${timeCommitmentFacets})`;
+  }
+
+  /**
    * Exclude list of campaign IDs.
    *
    * @param {Array} ids
@@ -146,6 +161,7 @@ class Algolia extends DataSource {
       orderBy = '',
       perPage = 20,
       term = '',
+      timeCommitments = [],
       excludeIds = [],
     } = options;
 
@@ -192,6 +208,11 @@ class Algolia extends DataSource {
     // If specified, append filter for online/offline campaigns
     if (!isNull(isOnline)) {
       filters += this.filterOnlineLocation(isOnline);
+    }
+
+    // If specified, append filter for campaign time commitments.
+    if (timeCommitments.length) {
+      filters += this.filterTimeCommitments(timeCommitments);
     }
 
     // If specified, append filter to exclude campaigns with provided IDs.

--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -91,7 +91,7 @@ class Algolia extends DataSource {
     return ` AND (${causeFacets})`;
   }
 
-    /**
+  /**
    * Filter search by campaigns containing these action types (using facet filtering).
    *
    * @param {Array} actionTypes
@@ -102,6 +102,20 @@ class Algolia extends DataSource {
     const actionTypeFacets = actionTypes.map(actionType => `actions.action_type:${actionType}`).join(' OR ');
 
     return ` AND (${actionTypeFacets})`;
+  }
+
+  /**
+   * Filter search by campaigns containing online location (boolean) (using facet filtering).
+   * 
+   * @param {Boolean} online
+   * @return {String}
+   */
+  filterOnlineLocation(online) {
+    if(!online) {
+      return ` AND NOT actions.online=1`;
+    }
+
+    return ` AND actions.online=1`
   }
 
   /**
@@ -122,6 +136,7 @@ class Algolia extends DataSource {
       actionTypes = [],
       cursor = '0',
       causes = [],
+      isOnline = null,
       isOpen = true,
       isGroupCampaign,
       hasScholarship = null,
@@ -170,6 +185,11 @@ class Algolia extends DataSource {
     // If specified, append filter for campaign action types.
     if (actionTypes.length) {
       filters += this.filterActionTypes(actionTypes);
+    }
+
+    // If specified, append filter for online/offline campaigns
+    if (!isNull(isOnline)) {
+      filters += this.filterOnlineLocation(isOnline);
     }
 
     // If specified, append filter to exclude campaigns with provided IDs.

--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -91,6 +91,19 @@ class Algolia extends DataSource {
     return ` AND (${causeFacets})`;
   }
 
+    /**
+   * Filter search by campaigns containing these action types (using facet filtering).
+   *
+   * @param {Array} actionTypes
+   * @return {String}
+   */
+  filterActionTypes(actionTypes) {
+    // e.g. ["make-something", "share-something"] => "actions.action_type:make-something OR actions.action_type:share-something".
+    const actionTypeFacets = actionTypes.map(actionType => `actions.action_type:${actionType}`).join(' OR ');
+
+    return ` AND (${actionTypeFacets})`;
+  }
+
   /**
    * Exclude list of campaign IDs.
    *
@@ -106,6 +119,7 @@ class Algolia extends DataSource {
    */
   async searchCampaigns(options = {}) {
     const {
+      actionTypes = [],
       cursor = '0',
       causes = [],
       isOpen = true,
@@ -151,6 +165,11 @@ class Algolia extends DataSource {
     // If specified, append filter for campaign causes.
     if (causes.length) {
       filters += this.filterCauses(causes);
+    }
+
+    // If specified, append filter for campaign action types.
+    if (actionTypes.length) {
+      filters += this.filterActionTypes(actionTypes);
     }
 
     // If specified, append filter to exclude campaigns with provided IDs.

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -35,6 +35,8 @@ const typeDefs = gql`
       perPage: Int
       "The search term specified or an empty string."
       term: String
+      "Filter by campaigns containing these time commitments"
+      timeCommitments: [String]
     ): AlgoliaCampaignCollection!
   }
 

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -31,6 +31,8 @@ const typeDefs = gql`
       cursor: String
       "Exclude campaigns with specified IDs"
       excludeIds: [Int]
+      "Filter by campaigns containing these action types."
+      actionTypes: [String]
     ): AlgoliaCampaignCollection!
   }
 

--- a/src/schema/algolia.js
+++ b/src/schema/algolia.js
@@ -11,28 +11,30 @@ import resolvers from '../resolvers/algolia';
 const typeDefs = gql`
   type Query {
     searchCampaigns(
-      "The search term specified or an empty string."
-      term: String
-      "Search for only open campaigns or only closed campaigns."
-      isOpen: Boolean
-      "Search for only group or non-group campaigns."
-      isGroupCampaign: Boolean
-      "Search for campaigns that have or do not have a scholarship."
-      hasScholarship: Boolean
+      "Filter by campaigns containing these action types."
+      actionTypes: [String]
       "Filter by campaigns containing these causes."
       causes: [String]
-      "Filter for campaigns that have a Contentful campaign associated."
-      hasWebsite: Boolean
-      "Number of results per page."
-      perPage: Int
-      "How to order the results (e.g. 'start_date,desc')."
-      orderBy: String
       "Pagination search cursor for the specified search location."
       cursor: String
       "Exclude campaigns with specified IDs"
       excludeIds: [Int]
-      "Filter by campaigns containing these action types."
-      actionTypes: [String]
+      "Search for campaigns that have or do not have a scholarship."
+      hasScholarship: Boolean
+      "Filter for campaigns that have a Contentful campaign associated."
+      hasWebsite: Boolean
+      "Filter by campaigns that are online or offline."
+      isOnline: Boolean
+      "Search for only open campaigns or only closed campaigns."
+      isOpen: Boolean
+      "Search for only group or non-group campaigns."
+      isGroupCampaign: Boolean
+      "How to order the results (e.g. 'start_date,desc')."
+      orderBy: String
+      "Number of results per page."
+      perPage: Int
+      "The search term specified or an empty string."
+      term: String
     ): AlgoliaCampaignCollection!
   }
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -436,8 +436,10 @@ const typeDefs = gql`
     createdAt: DateTime
     "The time when this action was last modified."
     updatedAt: DateTime
-    "How long will this action take to complete?"
+    "How long will this action take to complete? (human readable format)"
     timeCommitmentLabel: String
+    "How long will this action take to complete?"
+    timeCommitment: String
     "Aggregate post information for this action by school."
     schoolActionStats(
       "The school ID to display an action stat for."


### PR DESCRIPTION
### What's this PR do?

This pull request adds three new filters to the Algolia `searchCampaigns` Query to allow filtering campaigns by:
- action type
- location (online/offline)
- time commitment

### How should this be reviewed?

👀 

### Any background context you want to provide?

Please reference @mendelB's iconic overview of how facets work within Algolia and our site on his [PR](https://github.com/DoSomething/graphql/pull/294).

I will be updating the docs in rogue when our code freeze there ends, which i documented in [this new ticket](https://www.pivotaltracker.com/story/show/176647370).

Example Query:
```
{  
  searchCampaigns(actionTypes: ["make-something", "share-something"], isOnline:true, timeCommitments:["1.0-3.0"]) {
    edges {
      node {
        id
        actions {
          id
          actionType
          online
          timeCommitment
        }
    }
  }
}
```

Example Response:
```
   "data": {
    "searchCampaigns": {
      "edges": [
        {
          "campaignId": 946,
          "node": {
            "actions": [
              {
                "id": 794,
                "actionType": "share-something",
                "online": true,
                "timeCommitment": "1.0-3.0"
              }
            ]
          }
        },
        {
          "campaignId": 9009,
          "node": {
            "actions": [
              {
                "id": 839,
                "actionType": "share-something",
                "online": true,
                "timeCommitment": "<0.5"
              },
              {
                "id": 841,
                "actionType": "have-a-conversation",
                "online": false,
                "timeCommitment": "1.0-3.0"
              }
            ]
          }
        }
      ]
    }
  }
```
### Relevant tickets

References [Pivotal #176561802](https://www.pivotaltracker.com/story/show/176561802).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
