### PR TITLE
Add arguments to createSignup mutation

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -700,7 +700,10 @@ export const createSignup = async (args, context) => {
     ...requireAuthorizedRequest(context),
     body: JSON.stringify({
       campaign_id: args.campaignId,
+      group_id: args.groupId,
+      referrer_user_id: args.referrerUserId,
       details: args.details,
+      source_details: args.sourceDetails,
     }),
   });
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -388,7 +388,18 @@ const typeDefs = gql`
     "Delete a post. Requires staff/admin role."
     deletePost("The post ID to delete." id: Int!): Post
     "Create a signup."
-    createSignup(campaignId: Int!, detail: JSON): Signup
+    createSignup(
+      "The campaign ID for this signup."
+      campaignId: Int!
+      "The group ID for this signup."
+      groupId: Int
+      "The referrerUserId for this signup."
+      referrerUserId: String
+      "The details field for this signup."
+      details: JSON
+      "The source details for this signup."
+      sourceDetails: JSON
+    ): Signup
     "Delete a signup. Requires staff/admin role."
     deleteSignup("The signup ID to delete." id: Int!): Signup
   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds some arguments to the `createSignup` mutation.

### How should this be reviewed?
👀 

### Any background context you want to provide?
As part of migrating our campaign signup button on Phoenix to use GraphQL (And to eventually retire the Redux functionality), we need to involve these arguments [we're currently sending](https://github.com/DoSomething/phoenix-next/blob/762644987b6ac5527821bb449beb827a77bc11a9/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js#L52-#L65) to Rogue when creating signups.

### Relevant tickets

References [Pivotal #175291206](https://www.pivotaltracker.com/story/show/175291206).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.


**example request**
```
mutation {
	createSignup(
    campaignId: 9001
    groupId: 1
    referrerUserId: "5bbd00271f1c570099415d02"
    sourceDetails: "{\"contentful_id\":\"1234\",\"utm_source\":\"fastweb\"}" 
    details: "{\"affiliateOptIn\": true}") {
    id
    groupId
    referrerUserId
    source
    sourceDetails
    details
    group {
      id
      name
    }
  }
}
```

**response**
```
{
  "data": {
    "createSignup": {
      "id": 3698,
      "groupId": 1,
      "referrerUserId": "5bbd00271f1c570099415d02",
      "source": "phoenix",
      "sourceDetails": "{\"contentful_id\":\"1234\",\"utm_source\":\"fastweb\"}",
      "details": "{\"affiliateOptIn\": true}",
      "group": {
        "id": 1,
        "name": "New York City"
      }
    }
  },
...
```