### PR TITLE
Adds action reference field to TextPostTopic type

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -76,7 +76,7 @@ const linkSchema = gql`
     "The action that this topic should create photo posts for."
     action: Action
     "The campaign that this topic should create signups and photo posts for."
-    campaign: Campaign
+    campaign: Campaign @deprecated(reason: "Use 'action' relationship instead.")
   }
 
   extend type PhotoSubmissionBlock {
@@ -90,8 +90,10 @@ const linkSchema = gql`
   }
 
   extend type TextPostTopic {
+    "The action that this topic should create text posts for."
+    action: Action
     "The campaign that this topic should create signups and text posts for."
-    campaign: Campaign
+    campaign: Campaign @deprecated(reason: "Use 'action' relationship instead.")
   }
 
   extend type TextSubmissionBlock {
@@ -189,10 +191,12 @@ const linkResolvers = {
         // We assume the broadcast will be associated with the
         // action's campaign Id of the saidVotedTransition topic
         const actionId = broadcastTopic.saidVotedTransition.topic.actionId;
+
         // check in case the transition does not support an actionId
         if (!actionId) {
           return null;
         }
+
         return info.mergeInfo.delegateToSchema({
           schema: rogueSchema,
           operation: 'query',
@@ -215,11 +219,13 @@ const linkResolvers = {
         // We assume the broadcast will be associated with the
         // action's campaign Id of the saidYesTransition topic
         const actionId = broadcastTopic.saidYesTransition.topic.actionId;
+
         // AskYesNo broadcasts that reference an autoReplyTransition as the
         // saidYes field will not have an actionId set
         if (!actionId) {
           return null;
         }
+
         return info.mergeInfo.delegateToSchema({
           schema: rogueSchema,
           operation: 'query',
@@ -647,6 +653,21 @@ const linkResolvers = {
   },
 
   TextPostTopic: {
+    action: {
+      fragment: 'fragment ActionFragment on TextPostTopic { actionId }',
+      resolve(topic, args, context, info) {
+        return info.mergeInfo.delegateToSchema({
+          schema: rogueSchema,
+          operation: 'query',
+          fieldName: 'action',
+          args: {
+            id: topic.actionId,
+          },
+          context,
+          info,
+        });
+      },
+    },
     campaign: {
       fragment: 'fragment CampaignFragment on TextPostTopic { legacyCampaign }',
       resolve(topic, args, context, info) {

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -73,7 +73,7 @@ const linkSchema = gql`
   }
 
   extend type PhotoPostTopic {
-    "The action that this topic should create photo posts for."
+    "The action that this topic should create signups and photo posts for."
     action: Action
     "The campaign that this topic should create signups and photo posts for."
     campaign: Campaign @deprecated(reason: "Use 'action' relationship instead.")
@@ -90,7 +90,7 @@ const linkSchema = gql`
   }
 
   extend type TextPostTopic {
-    "The action that this topic should create text posts for."
+    "The action that this topic should create signups and text posts for."
     action: Action
     "The campaign that this topic should create signups and text posts for."
     campaign: Campaign @deprecated(reason: "Use 'action' relationship instead.")


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to get the Action associated with a TextPostTopic (it already exists for PhotoPostTopic).

Example request:
```
{
  topic(id: "7xT2zlxjjc2YskVwrpvQro") {
    id
    __typename
    ...TopicFields
  }
}

fragment TopicFields on TextPostTopic {
  actionId
  action {
    id
    volunteerCredit
    campaign {
      id
      endDate
    }
  }
  invalidText
}

```

Example response:
```
{
  "data": {
    "topic": {
      "id": "7xT2zlxjjc2YskVwrpvQro",
      "__typename": "TextPostTopic",
      "actionId": 1032,
      "action": {
        "id": 1032,
        "volunteerCredit": false,
        "campaign": {
          "id": 9057,
          "endDate": null
        }
      },
      "invalidText": "Sorry, I didn't understand that. Text back with your tip and we’ll send your tips out to young people across the country!\n\n(Or text Q if you have a question.)"
    }
  },
  ...
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

This will allow us to refactor Gambit to inspect the action of a text post or photo post topic to find the relevant campaign ID it should create signups for, allowing us to deprecate the redundant `campaign` reference field on the text/photo post topic content types (the `actionId` field was added after the initial `campaign` field existed, and we never did the cleanup to get rid of the redundant field)


### Relevant tickets

References [Pivotal #176602032](https://www.pivotaltracker.com/story/show/176602032).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
