### PR TITLE
Check for existence of a query variable before trying to add it to the query

### DIFF
--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -216,7 +216,7 @@ class Algolia extends DataSource {
     }
 
     // If specified, append filter to exclude campaigns with provided IDs.
-    if (excludedIds && excludeIds.length) {
+    if (excludeIds && excludeIds.length) {
       filters += this.filterExcludedIds(excludeIds);
     }
 

--- a/src/dataSources/Algolia.js
+++ b/src/dataSources/Algolia.js
@@ -196,12 +196,12 @@ class Algolia extends DataSource {
     }
 
     // If specified, append filter for campaign causes.
-    if (causes.length) {
+    if (causes && causes.length) {
       filters += this.filterCauses(causes);
     }
 
     // If specified, append filter for campaign action types.
-    if (actionTypes.length) {
+    if (actionTypes && actionTypes.length) {
       filters += this.filterActionTypes(actionTypes);
     }
 
@@ -211,12 +211,12 @@ class Algolia extends DataSource {
     }
 
     // If specified, append filter for campaign time commitments.
-    if (timeCommitments.length) {
+    if (timeCommitments && timeCommitments.length) {
       filters += this.filterTimeCommitments(timeCommitments);
     }
 
     // If specified, append filter to exclude campaigns with provided IDs.
-    if (excludeIds.length) {
+    if (excludedIds && excludeIds.length) {
       filters += this.filterExcludedIds(excludeIds);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check for query options that are an array. we don't want to add them to the query if they're empty because it will throw an error once it gets to Algolia.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Flagged by @mendelB and initially [opened a pr](https://github.com/DoSomething/phoenix-next/pull/2543) in phoenix, but this is the more appropriate place to fix. 

### Relevant tickets

References [Pivotal #173713718](https://www.pivotaltracker.com/story/show/173713718).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
