### PR TITLE
add sponsor type

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -166,6 +166,7 @@ const resolvers = {
     coverImage: linkResolver,
     articles: linkResolver,
     campaigns: linkResolver,
+    sponsors: linkResolver,
   },
   ImagesBlock: {
     images: linkResolver,

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -373,6 +373,8 @@ const typeDefs = gql`
     articles: [Page]
     "Any custom overrides for the home page."
     additionalContent: JSON
+    "The sponsored affiliates."
+    sponsors: [AffiliateBlock]
     ${entryFields}
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request exposes the 'sponsors' field that as added to contentful, we can now access them in graphQL

### How should this be reviewed?

...

### Any background context you want to provide?
<img width="1440" alt="Screen Shot 2020-11-25 at 12 42 05 PM" src="https://user-images.githubusercontent.com/20409413/108415506-038dea80-7204-11eb-8d34-c6b3935d7569.png">

...

### Relevant tickets

References [Pivotal #176745846](https://www.pivotaltracker.com/n/projects/2401401/stories/176745846).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
