### PR TITLE
Adding badges to User Schema

### DIFF
--- a/src/resolvers/northstar.js
+++ b/src/resolvers/northstar.js
@@ -76,6 +76,7 @@ const resolvers = {
       has(user, `featureFlags.${feature}`) &&
       user.featureFlags[feature] !== false,
     causes: user => listToEnums(user.causes),
+    badges: user => listToEnums(user.badges),
   },
 };
 

--- a/src/schema/northstar.js
+++ b/src/schema/northstar.js
@@ -84,6 +84,18 @@ const typeDefs = gql`
     SEXUAL_HARASSMENT_ASSAULT
   }
 
+  "The user's earned badges."
+  enum BadgeIdentifier {
+    SIGNUP
+    ONE_POST
+    TWO_POSTS
+    THREE_POSTS
+    BREAKDOWN
+    ONE_STAFF_FAVE
+    TWO_STAFF_FAVES
+    THREE_STAFF_FAVES
+  }
+
   "A DoSomething.org user profile."
   type User {
     "The user's Northstar ID."
@@ -124,7 +136,7 @@ const typeDefs = gql`
     sourceDetail: String
     "The user's email subscription status."
     emailSubscriptionStatus: Boolean
-    "The user's email subscription status."
+    "The user's email subscription choices."
     emailSubscriptionTopics: [EmailSubscriptionTopic]!
     "The user's SMS status."
     smsStatus: SubscriptionStatus
@@ -172,6 +184,8 @@ const typeDefs = gql`
     permalink: String @requires(fields: "id")
     "The causes areas this user is interested in."
     causes: [CauseIdentifier]
+    "The badges a user has earned."
+    badges: [BadgeIdentifier]
   }
 
   type Query {


### PR DESCRIPTION
### What's this PR do?

This pull request adds badges to the user schema and the list of possible badges as an enum. I updated the description for the email subscription topics since it was a duplicate of the email subscription status description.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Only adding this as an attribute we can get via a query vs setting up mutations since we are handling adding badges directly in Northstar.

### Relevant tickets

References [Pivotal #175820458](https://www.pivotaltracker.com/story/show/175820458).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
