### PR TITLE
Add QuestionnaireBlock type

### DIFF
--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -42,6 +42,7 @@ const contentTypeMappings = {
   petitionSubmissionAction: 'PetitionSubmissionBlock',
   photoSubmissionAction: 'PhotoSubmissionBlock',
   postGallery: 'PostGalleryBlock',
+  questionnaireAction: 'QuestionnaireBlock',
   quiz: 'QuizBlock',
   sectionBlock: 'SectionBlock',
   selectionSubmissionAction: 'SelectionSubmissionBlock',

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -572,6 +572,23 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type QuestionnaireBlock implements Block {
+    "Title of the questionnaire."
+    title: String
+    "List of questions."
+    questions: JSON
+    "Text displayed on the questionnnaire submission button."
+    buttonText: String
+    "Title of the information card displayed next to the questionnaire."
+    informationTitle: String
+    "Content of the information card displayed next to the questionnaire."
+    informationContent: String
+    "Content displayed in the affirmation page once the questionnaire is submitted."
+    affirmationContent: String
+    ${blockFields}
+    ${entryFields}
+  }
+
   type PhotoSubmissionBlock implements Block {
     "The Action ID that posts will be submitted for."
     actionId: Int


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `QuestionnaireBlock` to our Phoenix Contentful schema per the new content type (https://github.com/DoSomething/phoenix-next/pull/2571).

### How should this be reviewed?
👀 

### Any background context you want to provide?
Example Request:
```
{
  block(id: "3AkNW72uMvzZ23xZZ3xQnq") {
    ... on QuestionnaireBlock {
      title
      questions
      buttonText
      informationTitle
      informationContent
      affirmationContent
    }
  }
}
```

Response:
```
{
  "data": {
    "block": {
      "title": "Submit Your Tips",
      "questions": [
        {
          "title": "Are you going to school in person or online?",
          "actionId": "1",
          "placeholder": "Online"
        },
        {
          "title": "What's helping you cope?",
          "actionId": "2",
          "placeholder": "Herbal teas and hanging with my cat."
        },
        {
          "title": "Who is your biggest support?",
          "actionId": "3",
          "placeholder": "My great great grandmom."
        }
      ],
      "buttonText": "Submit",
      "informationTitle": "More Information",
      "informationContent": "Answer these questions to qualify for a $30,000 scholarship to NASA University. (No sweepstakes. Like just fill this out and you receive the bank.)",
      "affirmationContent": "Thanks for filling out the questionnaire. You're a star! May the various forces be with thee."
    }
  },
```

### Relevant tickets

References [Pivotal #176852206](https://www.pivotaltracker.com/story/show/176852206).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
