### PR TITLE
Adding Articles Page Schema

### DIFF
--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -193,6 +193,52 @@ export const getHomePage = async (context, preview = false) => {
 };
 
 /**
+ * Search for a Phoenix Contentful ArticlesPage entry.
+ *
+ * @param {Object} context
+ */
+export const getArticlesPage = async (context, preview = false) => {
+  const query = {
+    content_type: 'articlesPage',
+    order: '-sys.updatedAt',
+    limit: 1,
+  };
+
+  logger.debug('Loading Contentful HomePage entry', {
+    query,
+    preview,
+  });
+
+  // Choose the right cache and API for this request:
+  const cache = preview ? previewCache : contentCache;
+  const api = preview ? previewApi : contentApi;
+
+  // Read from cache or Contentful's Content API:
+  return cache.remember(`articlesPage:${spaceId}`, async () => {
+    try {
+      const json = await api.getEntries(query);
+
+      const item = json.items[0];
+
+      if (!item) {
+        return null;
+      }
+
+      return transformItem(item);
+    } catch (exception) {
+      logger.warn('Unable to load Contentful ArticlesPage entry', {
+        query,
+        spaceId,
+        preview,
+        error: exception.message,
+      });
+    }
+
+    return null;
+  });
+};
+
+/**
  * Search for a Phoenix Contentful Campaign entry by campaignId.
  *
  * @param {String} id

--- a/src/repositories/contentful/phoenix.js
+++ b/src/repositories/contentful/phoenix.js
@@ -204,7 +204,7 @@ export const getArticlesPage = async (context, preview = false) => {
     limit: 1,
   };
 
-  logger.debug('Loading Contentful HomePage entry', {
+  logger.debug('Loading Contentful ArticlesPage entry', {
     query,
     preview,
   });

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -6,6 +6,7 @@ import Loader from '../../loader';
 import config from '../../../config';
 import { stringToEnum, listToEnums } from '../helpers';
 import {
+  getArticlesPage,
   getHomePage,
   linkResolver,
   createImageUrl,
@@ -22,6 +23,7 @@ const contentTypeMappings = {
   actionStatsBlock: 'ActionStatsBlock',
   affiliates: 'AffiliateBlock',
   affirmation: 'AffirmationBlock',
+  articlesPage: 'ArticlesPage',
   callToAction: 'CallToActionBlock',
   campaign: 'CampaignWebsite',
   campaignDashboard: 'CampaignDashboard',
@@ -76,6 +78,8 @@ const resolvers = {
       Loader(context, preview).assets.load(id),
     affiliate: (_, { utmLabel, preview }, context) =>
       Loader(context, preview).affiliates.load(utmLabel),
+    articlesPage: (_, { preview }, context) =>
+      getArticlesPage(context, preview),
     campaignWebsite: (_, { id, preview }, context) =>
       Loader(context, preview).campaignWebsites.load(id),
     campaignWebsiteByCampaignId: (_, { campaignId, preview }, context) =>

--- a/src/resolvers/contentful/phoenix.js
+++ b/src/resolvers/contentful/phoenix.js
@@ -110,6 +110,13 @@ const resolvers = {
   Asset: {
     url: (asset, args) => createImageUrl(asset, args),
   },
+  ArticlesPage: {
+    coverImage: linkResolver,
+    featuredArticlesGalleryTop: linkResolver,
+    topicArticlesGalleryOne: linkResolver,
+    topicArticlesGalleryTwo: linkResolver,
+    featuredArticlesGalleryBottom: linkResolver,
+  },
   Block: {
     __resolveType: block => get(contentTypeMappings, block.contentType),
   },

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -413,10 +413,14 @@ const typeDefs = gql`
   type ArticlesPage {
     "This title is used internally to help find this content."
     internalTitle: String!
-    "The title for the articles page."
-    title: String!
     "Cover image for the articles page."
     coverImage: Asset
+    "The title for the top article on the articles page."
+    headerTitle: String
+    "The article for the top spot on the articles page."
+    headerArticle: Page!
+    "The optional custom text for the top article on the articles page."
+    headerLinkText: String
     "The title for the first featured gallery of articles."
     featuredArticlesGalleryTopTitle: String!
     "Featured Articles (page entries) rendered as a list on the articles page."
@@ -888,6 +892,7 @@ const typeDefs = gql`
     "Get an asset by ID."
     asset(id: String!, preview: Boolean = false): Asset
     affiliate(utmLabel: String!, preview: Boolean = false): AffiliateBlock
+    articlesPage(preview: Boolean = false): ArticlesPage
     campaignWebsite(id: String!, preview: Boolean = false): CampaignWebsite
     page(id: String!, preview: Boolean = false): Page
     pageBySlug(slug: String!, preview: Boolean = false): Page

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -410,6 +410,40 @@ const typeDefs = gql`
     ${entryFields}
   }
 
+  type ArticlesPage {
+    "This title is used internally to help find this content."
+    internalTitle: String!
+    "The title for the articles page."
+    title: String!
+    "Cover image for the articles page."
+    coverImage: Asset
+    "The title for the first featured gallery of articles."
+    featuredArticlesGalleryTopTitle: String!
+    "Featured Articles (page entries) rendered as a list on the articles page."
+    featuredArticlesGalleryTop: [Page]!
+    "The title for the first gallery of articles on a related topic."
+    topicArticlesGalleryOneTitle: String
+    "Articles (page entries) on a related topic rendered as a list on the articles page."
+    featuredArticlesGalleryOne: [Page]
+    "The title for the second gallery of articles on a related topic."
+    topicArticlesGalleryTwoTitle: String
+    "Articles (page entries) on a related topic rendered as a list on the articles page."
+    featuredArticlesGalleryTwo: [Page]
+    "The title for the bottom featured gallery of articles."
+    featuredArticlesGalleryBottomTitle: String
+    "Featured Articles (page entries) rendered as a list on the articles page."
+    featuredArticlesGalleryBottom: [Page]
+    "The title for the articles page CTA."
+    ctaTitle: String
+    "The text for the articles page CTA."
+    ctaText: String
+    "The button text for the articles page CTA."
+    ctaButtonText: String
+    "Any custom overrides for the home page."
+    additionalContent: JSON
+    ${entryFields}
+  }
+
   type ImagesBlock implements Block {
     "The images to be included in this block."
     images: [Asset]

--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -428,11 +428,11 @@ const typeDefs = gql`
     "The title for the first gallery of articles on a related topic."
     topicArticlesGalleryOneTitle: String
     "Articles (page entries) on a related topic rendered as a list on the articles page."
-    featuredArticlesGalleryOne: [Page]
+    topicArticlesGalleryOne: [Page]
     "The title for the second gallery of articles on a related topic."
     topicArticlesGalleryTwoTitle: String
     "Articles (page entries) on a related topic rendered as a list on the articles page."
-    featuredArticlesGalleryTwo: [Page]
+    topicArticlesGalleryTwo: [Page]
     "The title for the bottom featured gallery of articles."
     featuredArticlesGalleryBottomTitle: String
     "Featured Articles (page entries) rendered as a list on the articles page."


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `ArticlesPage` type to the phoenix schema and updates the Phoenix resolver to include the articles page with some additional `linkResolvers` added to array or asset type fields for the articles page. 

### How should this be reviewed?

👀  - let me know if there's anything glaringly missing.

### Any background context you want to provide?

Need to add in order to build out the articles page!

### Relevant tickets

References [Pivotal #177518666](https://www.pivotaltracker.com/story/show/177518666).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
