### PR TITLE
Adding a deprecated directive for these fields

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -199,9 +199,9 @@ const typeDefs = gql`
     "The author to attribute the quote to."
     author: PersonBlock
     "The heading for the share action on this block."
-    callToActionHeader: String
+    callToActionHeader: String @deprecated(reason: "No longer displaying in the block")
     "The description for the share action on this block."
-    callToActionDescription: String
+    callToActionDescription: String @deprecated(reason: "No longer displaying in the block")
     ${blockFields}
     ${entryFields}
   }


### PR DESCRIPTION
### What's this PR do?

This pull request updates two fields on the AffirmationBlock in our Phoenix schema to be deprecated since they are no longer a part of the content model.

### How should this be reviewed?

👀 

### Any background context you want to provide?

na

### Relevant tickets

References [Pivotal #174150633](https://www.pivotaltracker.com/story/show/174150633).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
