### PR TITLE
Deprecates caption fields on PhotoSubmission Action

### DIFF
--- a/src/schema/contentful/phoenix.js
+++ b/src/schema/contentful/phoenix.js
@@ -633,9 +633,9 @@ const typeDefs = gql`
     "Optional custom title of the text submission block."
     title: String
     "Optional label for the caption field, helping describe or prompt the user regarding what to submit."
-    captionFieldLabel: String
+    captionFieldLabel: String @deprecated(reason: "No longer displaying this field.")
     "Optional placeholder for the caption field, providing an example of what a text submission should look like."
-    captionFieldPlaceholderMessage: String
+    captionFieldPlaceholderMessage: String @deprecated(reason: "No longer displaying this field.")
     "Should the form ask for the quantity of items in member's photo submission?"
     showQuantityField: Boolean
     "Optional label for the quantity field."


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates these fields now that we are deleting them from the content model in contentful.

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #176179265](https://www.pivotaltracker.com/story/show/176179265).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
