### PR TITLE
Deprecate Caption Fields for Gambit Schema

### DIFF
--- a/src/repositories/contentful/gambit.js
+++ b/src/repositories/contentful/gambit.js
@@ -160,17 +160,11 @@ const getFields = json => {
   if (contentType === 'photoPostConfig') {
     return {
       actionId: getActionId(json),
-      askCaption:
-        fields.askCaptionMessage ||
-        'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.',
       askPhoto: fields.askPhotoMessage,
       askQuantity: fields.askQuantityMessage,
       askWhyParticipated: fields.askWhyParticipatedMessage,
       completedPhotoPost: fields.completedMenuMessage,
       completedPhotoPostAutoReply: fields.invalidCompletedMenuCommandMessage,
-      invalidCaption:
-        fields.invalidCaptionMessage ||
-        "Sorry, I didn't get that. Text Q if you have a question.\n\nText back a caption for your photo -- keep it short & sweet, under 60 characters please. (but more than 3!)",
       invalidQuantity: fields.invalidQuantityMessage,
       invalidPhoto: fields.invalidPhotoMessage,
       invalidWhyParticipated: fields.invalidWhyParticipatedMessage,

--- a/src/schema/contentful/gambit.js
+++ b/src/schema/contentful/gambit.js
@@ -113,6 +113,10 @@ const typeDefs = gql`
     askPhoto: String!
     "Template that asks user to resend a message with a photo."
     invalidPhoto: String!
+    "Template that asks user to reply with a photo caption."
+    askCaption: String @deprecated(reason: "Field no longer displayed or asked for in user flow.")
+    "Template that asks user to resend a message with a valid photo caption."
+    invalidCaption: String @deprecated(reason: "Field no longer displayed or asked for in user flow.")
     "Template that asks user to reply with why participated."
     askWhyParticipated: String!
     "Template that asks user to resend a message with a valid why participated."

--- a/src/schema/contentful/gambit.js
+++ b/src/schema/contentful/gambit.js
@@ -113,10 +113,6 @@ const typeDefs = gql`
     askPhoto: String!
     "Template that asks user to resend a message with a photo."
     invalidPhoto: String!
-    "Template that asks user to reply with a photo caption."
-    askCaption: String!
-    "Template that asks user to resend a message with a valid photo caption."
-    invalidCaption: String!
     "Template that asks user to reply with why participated."
     askWhyParticipated: String!
     "Template that asks user to resend a message with a valid why participated."


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates the `askCaption` and `invalidCaption` fields in the gambit schema now that we are removing it from the sms flow. It also removes the fields from the photoPostConfig return object. 

### How should this be reviewed?

Wasn't sure whether to leave them in the config or not, but it felt like it made sense to remove.

### Any background context you want to provide?

see ticket!

### Relevant tickets

References [Pivotal #175786378](https://www.pivotaltracker.com/story/show/175786378).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
