### PR TITLE
New Impact Quantity Fields on Action!

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -135,6 +135,28 @@ export const getPaginatedActionStats = async (args, context) => {
 };
 
 /**
+ * Fetch an action from Rogue by ID with Accepted Quantity.
+ *
+ * @param {Number} id
+ * @return {Object}
+ */
+export const getAcceptedQuantityOnAction = async (id, context) => {
+  logger.debug('Loading action from Rogue', { id });
+
+  const response = await fetch(
+    `${NORTHSTAR_URL}/api/v3/actions/${id}?include=accepted_quantity`,
+    authorizedRequest(context),
+  );
+
+  const json = await response.json();
+
+  const transformedJson = transformItem(json);
+
+  // pulling out the accepted quantity since it's what we need
+  return transformedJson.acceptedQuantity.data.quantity;
+};
+
+/**
  * Fetch a campaign from Rogue by ID.
  *
  * @param {Number} id

--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -138,7 +138,7 @@ export const getPaginatedActionStats = async (args, context) => {
  * Fetch an action from Rogue by ID with Accepted Quantity.
  *
  * @param {Number} id
- * @return {Object}
+ * @return {Int}
  */
 export const getAcceptedQuantityOnAction = async (id, context) => {
   logger.debug('Loading action from Rogue', { id });

--- a/src/resolvers/rogue.js
+++ b/src/resolvers/rogue.js
@@ -42,6 +42,7 @@ import {
   deletePost,
   createSignup,
   deleteSignup,
+  getAcceptedQuantityOnAction,
 } from '../repositories/rogue';
 
 /**
@@ -108,6 +109,8 @@ const resolvers = {
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
       getActionStats(args.schoolId, action.id, args.orderBy, context),
+    currentImactQuantity: (action, args, context) =>
+      getAcceptedQuantityOnAction(action.id, context),
   },
 
   Campaign: {

--- a/src/resolvers/rogue.js
+++ b/src/resolvers/rogue.js
@@ -109,7 +109,7 @@ const resolvers = {
       Loader(context).campaigns.load(action.campaignId, getFields(info)),
     schoolActionStats: (action, args, context) =>
       getActionStats(args.schoolId, action.id, args.orderBy, context),
-    currentImactQuantity: (action, args, context) =>
+    currentImpactQuantity: (action, args, context) =>
       getAcceptedQuantityOnAction(action.id, context),
   },
 

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -439,6 +439,8 @@ const typeDefs = gql`
     collectSchoolId: Boolean
     "Anonymous actions will not be attributed to a particular user in public galleries."
     anonymous: Boolean
+    "The Impact Goal for this action, e.g. 4000."
+    impactGoal: Int
     "The noun for this action, e.g. 'cards' or 'jeans'."
     noun: String
     "The verb for this action, e.g. 'donated' or 'created'."
@@ -458,6 +460,8 @@ const typeDefs = gql`
       "How to order the results (e.g. 'accepted_quantity,desc')."
       orderBy: String = "accepted_quantity,desc"
     ): [SchoolActionStat]
+    "The Current Total Impact of this action (amount reached toward the impact goal)."
+    currentImactQuantity: Int
   }
 
   "A campaign."

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -461,7 +461,7 @@ const typeDefs = gql`
       orderBy: String = "accepted_quantity,desc"
     ): [SchoolActionStat]
     "The Current Total Impact of this action (amount reached toward the impact goal)."
-    currentImactQuantity: Int
+    currentImpactQuantity: Int
   }
 
   "A campaign."


### PR DESCRIPTION
### What's this PR do?

This pull request adds:

- A function in the Rogue repositories to grab the acceptedQuantity for a particular action.
- A new resolver to set the number returned from ^^ as `currentImpactQuantity` field
- Two new fields: impactGoal and currentImpactQuantity to the Action schema.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We will be querying for these two fields in Phoenix for our updated progress bar, as well as in Aurora when displaying an actions fields.

### Relevant tickets

References [Pivotal #177933517](https://www.pivotaltracker.com/story/show/177933517).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
