### PR TITLE
Add has_website filter for signup index queries

### DIFF
--- a/src/repositories/rogue.js
+++ b/src/repositories/rogue.js
@@ -572,6 +572,7 @@ export const fetchSignups = async (args, context, additionalQuery) => {
     filter: {
       campaign_id: args.campaignId,
       group_id: args.groupId,
+      has_website: args.hasWebsite,
       northstar_id: args.userId,
       referrer_user_id: args.referrerUserId,
       source: args.source,

--- a/src/schema/rogue.js
+++ b/src/schema/rogue.js
@@ -269,6 +269,8 @@ const typeDefs = gql`
       source: String
       "The user ID to load signups for."
       userId: String
+      "Filter for signups whos parent campaign has a Contentful campaign associated."
+      hasWebsite: Boolean
       "The page of results to return."
       page: Int = 1
       "The number of results per page."
@@ -288,6 +290,8 @@ const typeDefs = gql`
       source: String
       "The user ID to load signups for."
       userId: String
+      "Filter for signups whos parent campaign has a Contentful campaign associated."
+      hasWebsite: Boolean
       "How to order the results (e.g. 'id,desc')."
       orderBy: String = "id,desc"
       "Get the first N results."


### PR DESCRIPTION
### What's this PR do?

This pull request adds the new `has_website` filter (https://github.com/DoSomething/northstar/pull/1242) to the `signups` & `paginatedSignups` queries.

### How should this be reviewed?
👀 

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #178248537](https://www.pivotaltracker.com/story/show/178248537).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
